### PR TITLE
feat(details,settings): configurable markdown font size via attached …

### DIFF
--- a/src/TombLauncher.Core/Dtos/CoreSettings.cs
+++ b/src/TombLauncher.Core/Dtos/CoreSettings.cs
@@ -8,6 +8,6 @@ public record SavegameCoreSettings(bool IsBackupEnabled, int? NumberOfVersionsTo
 
 public record AppearanceCoreSettings(string ApplicationTheme, bool IsGridViewDefault);
 
-public record GameDetailsCoreSettings(string WinePath, string UnzipFallbackMethod, (string Command, string CommandLineArguments) UnzipFallbackMethodCommandLine, List<CheckableItem<string>> EnabledPatterns, List<CheckableItem<string>> ExcludedFolders, bool AskForConfirmationBeforeWalkthrough);
+public record GameDetailsCoreSettings(string WinePath, string UnzipFallbackMethod, (string Command, string CommandLineArguments) UnzipFallbackMethodCommandLine, List<CheckableItem<string>> EnabledPatterns, List<CheckableItem<string>> ExcludedFolders, bool AskForConfirmationBeforeWalkthrough, int DescriptionFontSize = 18);
 
 public record ApplicationCoreSettings(string GitHubLink, CultureInfo ApplicationLanguage, int RandomGameMaxRerolls, string DatabasePath);

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -243,6 +243,8 @@
     <system:String x:Key="THE_CLEAN_UP_PROCESS_HAS_COMPLETED_SUCCESSFULLY">The clean up process has completed successfully!</system:String>
     <system:String x:Key="SPACE_USED_BY_GAME">Space used by game</system:String>
     <system:String x:Key="WINE_EXECUTABLE_PATH">Wine executable path</system:String>
+    <system:String x:Key="DESCRIPTION_FONT_SIZE">Description font size</system:String>
+    <system:String x:Key="DESCRIPTION_FONT_SIZE_TOOLTIP">Controls the base font size used in game descriptions. Headings scale proportionally.</system:String>
     <system:String x:Key="WINE_TOOLTIP_CONTENT">Wine is a compatibility layer that allows Windows programs to run under Linux. In order to play TRLE customs, you need to have it installed on your Linux system.</system:String>
     <system:String x:Key="UNZIP_FALLBACK_METHOD">Unzip fallback method</system:String>
     <system:String x:Key="INSERT_NEW_GAME">INSERT NEW GAME</system:String>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -242,6 +242,8 @@
     <system:String x:Key="THE_CLEAN_UP_PROCESS_HAS_COMPLETED_SUCCESSFULLY">Il processo di pulizia è stato completato con successo!</system:String>
     <system:String x:Key="SPACE_USED_BY_GAME">Spazio occupato per gioco</system:String>
     <system:String x:Key="WINE_EXECUTABLE_PATH">Percorso dell'eseguibile di Wine</system:String>
+    <system:String x:Key="DESCRIPTION_FONT_SIZE">Dimensione carattere descrizione</system:String>
+    <system:String x:Key="DESCRIPTION_FONT_SIZE_TOOLTIP">Controlla la dimensione del carattere di base nelle descrizioni. Gli heading si adattano proporzionalmente.</system:String>
     <system:String x:Key="WINE_TOOLTIP_CONTENT">Wine è un layer di compataibilità che consente di eseguire programmi Windows sotto Linux. Per poter giocare ai livelli custom di TRLE, è necessario che Wine sia installato sul sistema.</system:String>
     <system:String x:Key="UNZIP_FALLBACK_METHOD">Metodo di decompressione di fallback</system:String>
     <system:String x:Key="INSERT_NEW_GAME">INSERISCI UN NUOVO GIOCO</system:String>

--- a/src/TombLauncher/Configuration/LayeredAppConfiguration.cs
+++ b/src/TombLauncher/Configuration/LayeredAppConfiguration.cs
@@ -35,7 +35,8 @@ public class LayeredAppConfiguration : ILayeredAppConfiguration
         AskForConfirmationBeforeWalkthrough = User.GameDetails.AskForConfirmationBeforeWalkthrough.Coalesce(Defaults.GameDetails.AskForConfirmationBeforeWalkthrough),
         WinePath = User.GameDetails.WinePath.Coalesce(Defaults.GameDetails.WinePath),
         DocumentationPatterns = (Defaults.GameDetails.DocumentationPatterns ?? new()).MergeWithOverrides(User.GameDetails.DocumentationPatterns ?? new()),
-        DocumentationFolderExclusions = (Defaults.GameDetails.DocumentationFolderExclusions ?? new()).MergeWithOverrides(User.GameDetails.DocumentationFolderExclusions ?? new())
+        DocumentationFolderExclusions = (Defaults.GameDetails.DocumentationFolderExclusions ?? new()).MergeWithOverrides(User.GameDetails.DocumentationFolderExclusions ?? new()),
+        DescriptionFontSize = Defaults.GameDetails.DescriptionFontSize.Coalesce(User.GameDetails.DescriptionFontSize)
     };
 
     public ISavegamesConfig Savegames => new SavegamesConfig

--- a/src/TombLauncher/Configuration/Sections/GameDetailsConfig.cs
+++ b/src/TombLauncher/Configuration/Sections/GameDetailsConfig.cs
@@ -9,4 +9,5 @@ public class GameDetailsConfig : IGameDetailsConfig
     public string? WinePath { get; set; }
     public List<CheckableItem<string>>? DocumentationPatterns { get; set; }
     public List<CheckableItem<string>>? DocumentationFolderExclusions { get; set; }
+    public int? DescriptionFontSize { get; set; }
 }

--- a/src/TombLauncher/Configuration/Sections/IGameDetailsConfig.cs
+++ b/src/TombLauncher/Configuration/Sections/IGameDetailsConfig.cs
@@ -9,4 +9,5 @@ public interface IGameDetailsConfig
     string? WinePath { get; }
     List<CheckableItem<string>>? DocumentationPatterns { get; }
     List<CheckableItem<string>>? DocumentationFolderExclusions { get; }
+    int? DescriptionFontSize { get; }
 }

--- a/src/TombLauncher/Helpers/MarkdownTypography.cs
+++ b/src/TombLauncher/Helpers/MarkdownTypography.cs
@@ -26,7 +26,6 @@ public static class MarkdownTypography
     private const double H6Ratio        = 1.00;
     private const double BlockquoteRatio = 0.88;
 
-
     // ── Attached properties ──────────────────────────────────────────────────
 
     public static readonly AttachedProperty<double> BaseFontSizeProperty =

--- a/src/TombLauncher/Helpers/MarkdownTypography.cs
+++ b/src/TombLauncher/Helpers/MarkdownTypography.cs
@@ -1,0 +1,117 @@
+using System;
+using Avalonia;
+using Avalonia.Media;
+using Avalonia.Styling;
+using ColorTextBlock.Avalonia;
+using Markdown.Avalonia.Full;
+
+namespace TombLauncher.Helpers;
+
+/// <summary>
+/// Provides attached properties for <see cref="MarkdownScrollViewer"/> that inject
+/// a proportional typography scale into the control's Styles at runtime.
+/// <list type="bullet">
+///   <item><see cref="BaseFontSizeProperty"/> – body text size (pt); headings scale proportionally.</item>
+///   <item><see cref="FontFamilyProperty"/> – font family to apply; defaults to <c>Georgia, serif</c>.</item>
+/// </list>
+/// Both properties are independent: changing either one triggers a full style rebuild.
+/// </summary>
+public static class MarkdownTypography
+{
+    private const double H1Ratio        = 2.00;
+    private const double H2Ratio        = 1.55;
+    private const double H3Ratio        = 1.33;
+    private const double H4Ratio        = 1.22;
+    private const double H5Ratio        = 1.11;
+    private const double H6Ratio        = 1.00;
+    private const double BlockquoteRatio = 0.88;
+
+
+    // ── Attached properties ──────────────────────────────────────────────────
+
+    public static readonly AttachedProperty<double> BaseFontSizeProperty =
+        AvaloniaProperty.RegisterAttached<MarkdownScrollViewer, double>(
+            "BaseFontSize",
+            typeof(MarkdownTypography),
+            defaultValue: 18.0);
+
+    public static readonly AttachedProperty<FontFamily?> FontFamilyProperty =
+        AvaloniaProperty.RegisterAttached<MarkdownScrollViewer, FontFamily?>(
+            "FontFamily",
+            typeof(MarkdownTypography),
+            defaultValue: null);
+
+    static MarkdownTypography()
+    {
+        BaseFontSizeProperty.Changed.AddClassHandler<MarkdownScrollViewer>(OnScaleChanged);
+        FontFamilyProperty.Changed.AddClassHandler<MarkdownScrollViewer>(OnScaleChanged);
+    }
+
+    // ── Getters / Setters ────────────────────────────────────────────────────
+
+    public static double GetBaseFontSize(MarkdownScrollViewer viewer)
+        => viewer.GetValue(BaseFontSizeProperty);
+    public static void SetBaseFontSize(MarkdownScrollViewer viewer, double value)
+        => viewer.SetValue(BaseFontSizeProperty, value);
+
+    public static FontFamily? GetFontFamily(MarkdownScrollViewer viewer)
+        => viewer.GetValue(FontFamilyProperty);
+    public static void SetFontFamily(MarkdownScrollViewer viewer, FontFamily? value)
+        => viewer.SetValue(FontFamilyProperty, value);
+
+    // ── Internal ─────────────────────────────────────────────────────────────
+
+    private static void OnScaleChanged(MarkdownScrollViewer viewer, AvaloniaPropertyChangedEventArgs _)
+        => ApplyTypographyScale(viewer);
+
+    private static void ApplyTypographyScale(MarkdownScrollViewer viewer)
+    {
+        var baseSize = viewer.GetValue(BaseFontSizeProperty);
+        var font     = viewer.GetValue(FontFamilyProperty); // null = inherit from tree
+
+        viewer.Styles.Clear();
+
+        viewer.Styles.Add(BodyStyle(font, baseSize));
+        viewer.Styles.Add(HeadingStyle(font, "Heading1", Round(baseSize * H1Ratio), FontWeight.Bold));
+        viewer.Styles.Add(HeadingStyle(font, "Heading2", Round(baseSize * H2Ratio), FontWeight.SemiBold));
+        viewer.Styles.Add(HeadingStyle(font, "Heading3", Round(baseSize * H3Ratio), FontWeight.SemiBold));
+        viewer.Styles.Add(HeadingStyle(font, "Heading4", Round(baseSize * H4Ratio), FontWeight.Medium));
+        viewer.Styles.Add(HeadingStyle(font, "Heading5", Round(baseSize * H5Ratio), FontWeight.Medium));
+        viewer.Styles.Add(HeadingStyle(font, "Heading6", Round(baseSize * H6Ratio), FontWeight.Medium));
+        viewer.Styles.Add(BlockquoteStyle(font, Round(baseSize * BlockquoteRatio)));
+    }
+
+    private static Style BodyStyle(FontFamily? font, double size)
+    {
+        var s = new Style(x => x.OfType<CTextBlock>());
+        AddSetters(s, font, size, FontWeight.Normal, FontStyle.Normal);
+        return s;
+    }
+
+    private static Style HeadingStyle(FontFamily? font, string cls, double size, FontWeight weight)
+    {
+        var s = new Style(x => x.OfType<CTextBlock>().Class(cls));
+        AddSetters(s, font, size, weight, FontStyle.Normal);
+        return s;
+    }
+
+    private static Style BlockquoteStyle(FontFamily? font, double size)
+    {
+        var s = new Style(x => x.Class("Blockquote").Descendant().OfType<CTextBlock>());
+        AddSetters(s, font, size, FontWeight.Normal, FontStyle.Italic);
+        return s;
+    }
+
+    private static void AddSetters(Style s, FontFamily? font, double size,
+        FontWeight weight, FontStyle style)
+    {
+        if (font != null)
+            s.Setters.Add(new Setter(CTextBlock.FontFamilyProperty, font));
+        s.Setters.Add(new Setter(CTextBlock.FontSizeProperty, size));
+        s.Setters.Add(new Setter(CTextBlock.FontWeightProperty, weight));
+        s.Setters.Add(new Setter(CTextBlock.FontStyleProperty, style));
+    }
+
+    private static double Round(double value)
+        => Math.Round(value, MidpointRounding.AwayFromZero);
+}

--- a/src/TombLauncher/Services/GameDetailsService.cs
+++ b/src/TombLauncher/Services/GameDetailsService.cs
@@ -57,6 +57,7 @@ public class GameDetailsService : IViewService
         target.AskForConfirmationBeforeOpeningWalkthrough = gameDetailsSettings.AskForConfirmationBeforeWalkthrough;
         target.EnabledPatterns = gameDetailsSettings.EnabledPatterns.Select(p => p.Value).ToList();
         target.IgnoredFolders = gameDetailsSettings.ExcludedFolders.Select(p => p.Value).ToList();
+        target.DescriptionFontSize = gameDetailsSettings.DescriptionFontSize;
     }
 
     public void OpenGameFolder(string gameFolder)

--- a/src/TombLauncher/Services/SettingsPageService.cs
+++ b/src/TombLauncher/Services/SettingsPageService.cs
@@ -109,6 +109,7 @@ public class SettingsPageService : IViewService
         return new GameDetailsSettingsViewModel(settingsPage)
         {
             AskForConfirmationBeforeWalkthrough = gd.AskForConfirmationBeforeWalkthrough.GetValueOrDefault(),
+            DescriptionFontSize = gd.DescriptionFontSize ?? 18,
             DocumentationPatterns = new EditablePatternListBoxViewModel() { TargetCollection = settings.EnabledPatterns.ToObservableCollection(), HeaderIcon = PackIconRemixIconKind.FileTextLine },
             FolderExclusions = new EditableFolderExclusionsListBoxViewModel() { TargetCollection = settings.ExcludedFolders.ToObservableCollection(), HeaderIcon = PackIconRemixIconKind.FolderLine },
             WinePath = settings.WinePath

--- a/src/TombLauncher/Services/SettingsProvider.cs
+++ b/src/TombLauncher/Services/SettingsProvider.cs
@@ -112,7 +112,8 @@ public class SettingsProvider : ISettingsProvider
             methodToUse != null ? (methodToUse.Command, methodToUse.CommandLineArguments) : (string.Empty, string.Empty),
             gd.DocumentationPatterns?.ToList() ?? new List<CheckableItem<string>>(),
             gd.DocumentationFolderExclusions?.ToList() ?? new List<CheckableItem<string>>(),
-            gd.AskForConfirmationBeforeWalkthrough.GetValueOrDefault()
+            gd.AskForConfirmationBeforeWalkthrough.GetValueOrDefault(),
+            gd.DescriptionFontSize ?? 18
         );
     }
 

--- a/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading.Tasks;
@@ -34,6 +34,7 @@ public partial class GameDetailsViewModel : PageViewModel
     [ObservableProperty] private ObservableCollection<CommandViewModel> _setupCommands = new ObservableCollection<CommandViewModel>();
     [ObservableProperty] private ObservableCollection<FileInfo> _documentationFiles = new ObservableCollection<FileInfo>();
     [ObservableProperty] private GameWithStatsViewModel _game = null!;
+    [ObservableProperty] private int _descriptionFontSize = 18;
     [ObservableProperty] private ObservableCollection<GameLinkViewModel> _walkthroughLinks = new ObservableCollection<GameLinkViewModel>();
     public List<string> EnabledPatterns { get; set; } = new List<string>();
     public List<string> IgnoredFolders { get; set; } = new List<string>();

--- a/src/TombLauncher/ViewModels/Pages/Settings/GameDetailsSettingsViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/Settings/GameDetailsSettingsViewModel.cs
@@ -18,6 +18,9 @@ public partial class GameDetailsSettingsViewModel : SettingsSectionViewModelBase
     public bool IsWinePathOptionVisible => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
     [ObservableProperty] private bool _askForConfirmationBeforeWalkthrough;
     [ObservableProperty] private string _winePath = string.Empty;
+    [ObservableProperty] private int _descriptionFontSize = 18;
+
+    public IReadOnlyList<int> AvailableFontSizes { get; } = new[] { 12, 14, 16, 18, 20 };
 
     public EditablePatternListBoxViewModel? DocumentationPatterns
     {
@@ -73,6 +76,7 @@ public partial class GameDetailsSettingsViewModel : SettingsSectionViewModelBase
     {
         userConfig.GameDetails.AskForConfirmationBeforeWalkthrough = AskForConfirmationBeforeWalkthrough;
         userConfig.GameDetails.WinePath = WinePath;
+        userConfig.GameDetails.DescriptionFontSize = DescriptionFontSize;
         userConfig.GameDetails.DocumentationPatterns = DocumentationPatterns?.TargetCollection.ToList() ?? new List<CheckableItem<string>>();
         userConfig.GameDetails.DocumentationFolderExclusions = FolderExclusions?.TargetCollection.ToList() ?? new List<CheckableItem<string>>();
     }

--- a/src/TombLauncher/Views/GameDetailsSettingsView.axaml
+++ b/src/TombLauncher/Views/GameDetailsSettingsView.axaml
@@ -28,6 +28,16 @@
         
         <ToggleSwitch IsChecked="{Binding AskForConfirmationBeforeWalkthrough}"
                       Content="{loc:Translate ASK_FOR_CONFIRMATION_BEFORE_OPENING_A_WALKTHROUGH}" />
+        <DockPanel LastChildFill="True">
+            <controls:Infotip DockPanel.Dock="Right"
+                              Header="{loc:Translate DESCRIPTION_FONT_SIZE}"
+                              ToolTipContent="{loc:Translate DESCRIPTION_FONT_SIZE_TOOLTIP}" />
+            <TextBlock VerticalAlignment="Center" Margin="0 0 8 0"
+                       Text="{loc:Translate DESCRIPTION_FONT_SIZE}" />
+            <ComboBox ItemsSource="{Binding AvailableFontSizes}"
+                      SelectedItem="{Binding DescriptionFontSize}"
+                      HorizontalAlignment="Left" Width="80" />
+        </DockPanel>
         <views:EditableListBox DataContext="{Binding DocumentationPatterns}"/>
         <views:EditableListBox DataContext="{Binding FolderExclusions}"/>
     </StackPanel>

--- a/src/TombLauncher/Views/Pages/GameDetailsView.axaml
+++ b/src/TombLauncher/Views/Pages/GameDetailsView.axaml
@@ -6,8 +6,8 @@
              xmlns:pages="clr-namespace:TombLauncher.ViewModels.Pages"
              xmlns:views="clr-namespace:TombLauncher.Views"
              xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
-             xmlns:mdxaml="https://github.com/whistyun/Markdown.Avalonia"
-              xmlns:ctb="clr-namespace:ColorTextBlock.Avalonia;assembly=ColorTextBlock.Avalonia"
+              xmlns:mdxaml="https://github.com/whistyun/Markdown.Avalonia"
+              xmlns:helpers="clr-namespace:TombLauncher.Helpers"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="TombLauncher.Views.Pages.GameDetailsView"
              x:Name="GameDetailsViewRoot"
@@ -72,53 +72,10 @@
             <mdxaml:MarkdownScrollViewer x:Name="DescriptionViewer"
                                           DockPanel.Dock="Bottom"
                                           Margin="0 8 0 0"
+                                          helpers:MarkdownTypography.FontFamily="{StaticResource Spectral}"
+                                          helpers:MarkdownTypography.BaseFontSize="{Binding DescriptionFontSize}"
                                           Markdown="{Binding Game.GameMetadata.Description,
-                                                     Converter={StaticResource MarkdownDescriptionConverter}}">
-                <mdxaml:MarkdownScrollViewer.Styles>
-                    <!-- Base: paragraph body text (base = 18) -->
-                    <Style Selector="ctb|CTextBlock">
-                        <Setter Property="FontFamily" Value="{StaticResource Spectral}" />
-                        <Setter Property="FontSize"   Value="18" />
-                    </Style>
-                    <!-- Headings: proportional scale from 18px -->
-                    <Style Selector="ctb|CTextBlock.Heading1">
-                        <Setter Property="FontFamily"  Value="{StaticResource Spectral}" />
-                        <Setter Property="FontSize"    Value="36" />
-                        <Setter Property="FontWeight"  Value="Bold" />
-                    </Style>
-                    <Style Selector="ctb|CTextBlock.Heading2">
-                        <Setter Property="FontFamily"  Value="{StaticResource Spectral}" />
-                        <Setter Property="FontSize"    Value="28" />
-                        <Setter Property="FontWeight"  Value="SemiBold" />
-                    </Style>
-                    <Style Selector="ctb|CTextBlock.Heading3">
-                        <Setter Property="FontFamily"  Value="{StaticResource Spectral}" />
-                        <Setter Property="FontSize"    Value="24" />
-                        <Setter Property="FontWeight"  Value="SemiBold" />
-                    </Style>
-                    <Style Selector="ctb|CTextBlock.Heading4">
-                        <Setter Property="FontFamily"  Value="{StaticResource Spectral}" />
-                        <Setter Property="FontSize"    Value="22" />
-                        <Setter Property="FontWeight"  Value="Medium" />
-                    </Style>
-                    <Style Selector="ctb|CTextBlock.Heading5">
-                        <Setter Property="FontFamily"  Value="{StaticResource Spectral}" />
-                        <Setter Property="FontSize"    Value="20" />
-                        <Setter Property="FontWeight"  Value="Medium" />
-                    </Style>
-                    <Style Selector="ctb|CTextBlock.Heading6">
-                        <Setter Property="FontFamily"  Value="{StaticResource Spectral}" />
-                        <Setter Property="FontSize"    Value="18" />
-                        <Setter Property="FontWeight"  Value="Medium" />
-                    </Style>
-                    <!-- Blockquote: italic, slightly smaller -->
-                    <Style Selector=".Blockquote ctb|CTextBlock">
-                        <Setter Property="FontFamily"  Value="{StaticResource Spectral}" />
-                        <Setter Property="FontSize"    Value="16" />
-                        <Setter Property="FontStyle"   Value="Italic" />
-                    </Style>
-                </mdxaml:MarkdownScrollViewer.Styles>
-            </mdxaml:MarkdownScrollViewer>
+                                                     Converter={StaticResource MarkdownDescriptionConverter}}" />
 
         </DockPanel>
     </Grid>


### PR DESCRIPTION
…property

Add MarkdownTypography.BaseFontSize and MarkdownTypography.FontFamily attached properties that dynamically inject a proportional CTextBlock style scale into MarkdownScrollViewer.Styles at runtime.

- New Helpers/MarkdownTypography.cs: generic, font-agnostic attached properties (font is specified by the caller, not hardcoded; falls back to tree-inherited Avalonia default if FontFamily is not set)
- Scale ratios: H1=2x, H2=1.55x, H3=1.33x, H4=1.22x, H5=1.11x, blockquote=0.88x
- GameDetailsView.axaml: 45 lines of hardcoded XAML styles → 2 attached properties
- IGameDetailsConfig + GameDetailsConfig: add DescriptionFontSize (int, default 18)
- GameDetailsCoreSettings record: add DescriptionFontSize positional param (default 18)
- SettingsProvider, SettingsPageService, GameDetailsService: propagate setting
- GameDetailsViewModel + GameDetailsSettingsViewModel: expose DescriptionFontSize (int)
- GameDetailsSettingsView: ComboBox with preset sizes 12/14/16/18/20 pt
- Localization: add DESCRIPTION_FONT_SIZE + DESCRIPTION_FONT_SIZE_TOOLTIP (en/it)