### PR TITLE
fix(ci): skip tag creation if tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,8 +168,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag v$VERSION
-          git push origin v$VERSION
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists, skipping"
+          else
+            git tag v$VERSION
+            git push origin v$VERSION
+          fi
 
       - name: Generate release notes
         uses: orhun/git-cliff-action@v4


### PR DESCRIPTION
Allows re-running the release pipeline without failing on duplicate tags.