### PR TITLE
feat(ui): add website link to sidebar navigation

### DIFF
--- a/src/TombLauncher.Core/Dtos/Configuration/CoreSettings.cs
+++ b/src/TombLauncher.Core/Dtos/Configuration/CoreSettings.cs
@@ -1,8 +1,6 @@
-using System.Collections.Generic;
 using System.Globalization;
-using TombLauncher.Core.Dtos;
 
-namespace TombLauncher.Configuration;
+namespace TombLauncher.Core.Dtos.Configuration;
 
 public record SavegameCoreSettings(bool IsBackupEnabled, int? NumberOfVersionsToKeep, int ProcessingDelay);
 
@@ -10,4 +8,4 @@ public record AppearanceCoreSettings(string ApplicationTheme, bool IsGridViewDef
 
 public record GameDetailsCoreSettings(string UnzipFallbackMethod, (string Command, string CommandLineArguments) UnzipFallbackMethodCommandLine, List<CheckableItem<string>> EnabledPatterns, List<CheckableItem<string>> ExcludedFolders, bool AskForConfirmationBeforeWalkthrough, int DescriptionFontSize = 18);
 
-public record ApplicationCoreSettings(string GitHubLink, CultureInfo ApplicationLanguage, int RandomGameMaxRerolls, string DatabasePath);
+public record ApplicationCoreSettings(string GitHubLink, string WebsiteLink, CultureInfo ApplicationLanguage, int RandomGameMaxRerolls, string DatabasePath);

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -211,6 +211,7 @@
     <system:String x:Key="LAUNCHING_COMMUNITY_PATCH_SETUP_FOR_GAMENAME">Launching community patch setup for {0}</system:String>
     <system:String x:Key="COMMUNITY_PATCH_SETUP">Community patch setup</system:String>
     <system:String x:Key="OPEN_TOMB_LAUNCHER_S_GITHUB_PAGE">Open Tomb Launcher's GitHub page</system:String>
+    <system:String x:Key="OPEN_WEBSITE">Open Tomb Launcher's website</system:String>
     <system:String x:Key="GRID_VIEW">Grid view</system:String>
     <system:String x:Key="TABLE_VIEW">Table view</system:String>
     <system:String x:Key="SHOW_GAMES_AS">Show games as</system:String>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -211,6 +211,7 @@
     <system:String x:Key="LAUNCHING_COMMUNITY_PATCH_SETUP_FOR_GAMENAME">Avvio dell'utility di configurazione della patch della community per {0}</system:String>
     <system:String x:Key="COMMUNITY_PATCH_SETUP">Setup patch della community</system:String>
     <system:String x:Key="OPEN_TOMB_LAUNCHER_S_GITHUB_PAGE">Apri la pagina GitHub di Tomb Launcher</system:String>
+    <system:String x:Key="OPEN_WEBSITE">Apri il sito di Tomb Launcher</system:String>
     <system:String x:Key="GRID_VIEW">Vista griglia</system:String>
     <system:String x:Key="TABLE_VIEW">Vista tabella</system:String>
     <system:String x:Key="SHOW_GAMES_AS">Visualizza i giochi come</system:String>

--- a/src/TombLauncher/Configuration/LayeredAppConfiguration.cs
+++ b/src/TombLauncher/Configuration/LayeredAppConfiguration.cs
@@ -16,7 +16,8 @@ public class LayeredAppConfiguration : ILayeredAppConfiguration
         ApplicationLanguage = User.Application.ApplicationLanguage.Coalesce(Defaults.Application.ApplicationLanguage),
         DatabasePath = User.Application.DatabasePath.Coalesce(Defaults.Application.DatabasePath),
         MinimumLogLevel = User.Application.MinimumLogLevel.Coalesce(Defaults.Application.MinimumLogLevel),
-        GitHubLink = Defaults.Application.GitHubLink
+        GitHubLink = Defaults.Application.GitHubLink,
+        WebsiteLink = Defaults.Application.WebsiteLink
     };
 
     public IAppearanceConfig Appearance => new AppearanceConfig

--- a/src/TombLauncher/Configuration/Sections/ApplicationConfig.cs
+++ b/src/TombLauncher/Configuration/Sections/ApplicationConfig.cs
@@ -8,4 +8,5 @@ public class ApplicationConfig : IApplicationConfig
     public string? DatabasePath { get; set; }
     public LogLevel? MinimumLogLevel { get; set; }
     public string? GitHubLink { get; set; }
+    public string? WebsiteLink { get; set; }
 }

--- a/src/TombLauncher/Configuration/Sections/IApplicationConfig.cs
+++ b/src/TombLauncher/Configuration/Sections/IApplicationConfig.cs
@@ -8,4 +8,5 @@ public interface IApplicationConfig
     string? DatabasePath { get; }
     LogLevel? MinimumLogLevel { get; }
     string? GitHubLink { get; }
+    string? WebsiteLink { get; }
 }

--- a/src/TombLauncher/Services/ISettingsProvider.cs
+++ b/src/TombLauncher/Services/ISettingsProvider.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using TombLauncher.Configuration;
 using TombLauncher.Contracts.Downloaders;
 using TombLauncher.Core.Dtos;
+using TombLauncher.Core.Dtos.Configuration;
 
 namespace TombLauncher.Services;
 

--- a/src/TombLauncher/Services/SettingsProvider.cs
+++ b/src/TombLauncher/Services/SettingsProvider.cs
@@ -5,11 +5,10 @@ using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using TombLauncher.Configuration;
 using TombLauncher.Contracts.Downloaders;
-using TombLauncher.Core.Extensions;
 using TombLauncher.Core.PlatformSpecific;
-using TombLauncher.Core.Utils;
 using TombLauncher.Core.Dtos;
 using TombLauncher.Contracts.Enums;
+using TombLauncher.Core.Dtos.Configuration;
 
 namespace TombLauncher.Services;
 
@@ -35,6 +34,7 @@ public class SettingsProvider : ISettingsProvider
         var wp = _appConfiguration.WelcomePage;
         return new ApplicationCoreSettings(
             app.GitHubLink ?? string.Empty,
+            app.WebsiteLink ?? string.Empty,
             new CultureInfo(app.ApplicationLanguage ?? "en-US"),
             wp.RandomGameMaxRerolls.GetValueOrDefault(),
             app.DatabasePath ?? "TombLauncher.sqlite"

--- a/src/TombLauncher/ViewModels/MainWindowViewModel.cs
+++ b/src/TombLauncher/ViewModels/MainWindowViewModel.cs
@@ -71,6 +71,14 @@ public partial class MainWindowViewModel : WindowViewModelBase
             Command = new RelayCommand(OpenGithub)
         };
 
+        WebsiteLinkItem = new CommandViewModel()
+        {
+            Tooltip = "OPEN_WEBSITE".GetLocalizedString(),
+            Icon = PackIconRemixIconKind.GlobalLine,
+            Text = "OPEN_WEBSITE".GetLocalizedString(),
+            Command = new RelayCommand(OpenWebsite)
+        };
+
         Title = "Tomb Launcher";
         // Initialize default view
         SelectedMenuItem = MenuItems.First();
@@ -108,12 +116,19 @@ public partial class MainWindowViewModel : WindowViewModelBase
     [ObservableProperty] private NotificationListViewModel _notificationListViewModel;
     [ObservableProperty] private MainMenuItemViewModel _settingsItem;
     [ObservableProperty] private CommandViewModel _gitHubLinkItem;
+    [ObservableProperty] private CommandViewModel _websiteLinkItem;
     [ObservableProperty] private bool _isSettingsOpen;
 
     private void OpenGithub()
     {
         var gitHubLink = _settingsProvider.GetApplicationSettings().GitHubLink;
         _platformSpecificFeatures.OpenUrl(gitHubLink);
+    }
+
+    private void OpenWebsite()
+    {
+        var websiteLink = _settingsProvider.GetApplicationSettings().WebsiteLink;
+        _platformSpecificFeatures.OpenUrl(websiteLink);
     }
 
     private bool _isPaneOpen;

--- a/src/TombLauncher/Views/MainWindow.axaml
+++ b/src/TombLauncher/Views/MainWindow.axaml
@@ -36,6 +36,7 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <controls:IconButton Grid.Row="0" 
                                      Classes="icon-only"
@@ -63,7 +64,27 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
-                <ListBoxItem Grid.Row="2" Content="{Binding GitHubLinkItem}" x:Name="GitHubLinkItem" 
+                <ListBoxItem Grid.Row="2" Content="{Binding WebsiteLinkItem}" x:Name="WebsiteLinkItem" 
+                             ToolTip.Tip="{Binding WebsiteLinkItem.Tooltip}">
+                    <Interaction.Behaviors>
+                        <EventTriggerBehavior EventName="PointerReleased" 
+                                              SourceObject="WebsiteLinkItem">
+                            <EventTriggerBehavior.Actions>
+                                <InvokeCommandAction Command="{Binding WebsiteLinkItem.Command}"/>
+                            </EventTriggerBehavior.Actions>
+                        </EventTriggerBehavior>
+                    </Interaction.Behaviors>
+                    <ListBoxItem.ContentTemplate>
+                        <DataTemplate DataType="{x:Type viewModels:CommandViewModel}">
+                            <StackPanel Spacing="20" 
+                                        Orientation="Horizontal">
+                                <iconPacks:PackIconRemixIcon Kind="{Binding Icon}" />
+                                <TextBlock Text="{Binding Text}"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBoxItem.ContentTemplate>
+                </ListBoxItem>
+                <ListBoxItem Grid.Row="3" Content="{Binding GitHubLinkItem}" x:Name="GitHubLinkItem" 
                              ToolTip.Tip="{Binding GitHubLinkItem.Tooltip}">
                     <Interaction.Behaviors>
                         <EventTriggerBehavior EventName="PointerReleased" 
@@ -83,7 +104,7 @@
                         </DataTemplate>
                     </ListBoxItem.ContentTemplate>
                 </ListBoxItem>
-                <ListBoxItem Grid.Row="3" 
+                <ListBoxItem Grid.Row="4" 
                              Content="{Binding SettingsItem}" 
                              x:Name="SettingsItem" 
                              IsSelected="{Binding IsSettingsOpen}">

--- a/src/TombLauncher/appsettings.json
+++ b/src/TombLauncher/appsettings.json
@@ -3,7 +3,8 @@
     "MinimumLogLevel": "Information",
     "DatabasePath": "./TombLauncher.db",
     "ApplicationLanguage": "en-US",
-    "GitHubLink": "https://github.com/ALDamico/TombLauncher"
+    "GitHubLink": "https://github.com/ALDamico/TombLauncher",
+    "WebsiteLink": "https://tomblauncher.app"
   },
   "Appearance": {
     "ApplicationTheme": "Default",


### PR DESCRIPTION
Adds a link to tomblauncher.app in the main sidebar, alongside the existing GitHub link. Includes WebsiteLink in the config layer, ApplicationCoreSettings DTO, and both localization files (en-US / it-IT). Also moves CoreSettings.cs to the Dtos/Configuration subfolder.