### PR TITLE
feat(ui): add About page with acknowledgements (#110)

### DIFF
--- a/src/TombLauncher.Controls/HeroSection.axaml
+++ b/src/TombLauncher.Controls/HeroSection.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:localization="clr-namespace:TombLauncher.Localization;assembly=TombLauncher.Localization"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="TombLauncher.Controls.HeroSection">
+    <StackPanel>
+        <TextBlock Classes="h1" Text="TOMB LAUNCHER" Margin="0,8,0,4" />
+        <TextBlock Text="{localization:Translate WELCOME_SUBTITLE}"
+                   HorizontalAlignment="Center"
+                   Foreground="{DynamicResource SecondaryBrush}"
+                   FontSize="14"
+                   Margin="0,0,0,16" />
+    </StackPanel>
+</UserControl>

--- a/src/TombLauncher.Controls/HeroSection.axaml.cs
+++ b/src/TombLauncher.Controls/HeroSection.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TombLauncher.Controls;
+
+public partial class HeroSection : UserControl
+{
+    public HeroSection()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/TombLauncher.Controls/SidebarNavigationItem.axaml
+++ b/src/TombLauncher.Controls/SidebarNavigationItem.axaml
@@ -1,0 +1,13 @@
+<ListBoxItem xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
+             mc:Ignorable="d"
+             x:Class="TombLauncher.Controls.SidebarNavigationItem"
+             x:Name="Root">
+    <StackPanel Spacing="20" Orientation="Horizontal">
+        <iconPacks:PackIconRemixIcon Kind="{Binding #Root.Icon}" />
+        <TextBlock Text="{Binding #Root.Text}" />
+    </StackPanel>
+</ListBoxItem>

--- a/src/TombLauncher.Controls/SidebarNavigationItem.axaml.cs
+++ b/src/TombLauncher.Controls/SidebarNavigationItem.axaml.cs
@@ -1,0 +1,51 @@
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using IconPacks.Avalonia.RemixIcon;
+
+namespace TombLauncher.Controls;
+
+public partial class SidebarNavigationItem : ListBoxItem
+{
+    public SidebarNavigationItem()
+    {
+        InitializeComponent();
+    }
+
+    protected override Type StyleKeyOverride => typeof(ListBoxItem);
+
+    public static readonly StyledProperty<ICommand?> CommandProperty =
+        AvaloniaProperty.Register<SidebarNavigationItem, ICommand?>(nameof(Command));
+
+    public ICommand? Command
+    {
+        get => GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    public static readonly StyledProperty<PackIconRemixIconKind> IconProperty =
+        AvaloniaProperty.Register<SidebarNavigationItem, PackIconRemixIconKind>(nameof(Icon));
+
+    public PackIconRemixIconKind Icon
+    {
+        get => GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+
+    public static readonly StyledProperty<string> TextProperty =
+        AvaloniaProperty.Register<SidebarNavigationItem, string>(nameof(Text), string.Empty);
+
+    public string Text
+    {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+        if (e.InitialPressMouseButton == MouseButton.Left)
+            Command?.Execute(null);
+    }
+}

--- a/src/TombLauncher.Core/PlatformSpecific/IPlatformSpecificFeatures.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/IPlatformSpecificFeatures.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using TombLauncher.Core.Dtos;
 
 namespace TombLauncher.Core.PlatformSpecific;

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -397,5 +397,9 @@
     <system:String x:Key="LOADING_SAVEGAMES">Loading savegames...</system:String>
     <system:String x:Key="TOGGLE_FULLSCREEN">Toggle full screen (F11)</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Backing up savegames...</system:String>
+    <system:String x:Key="ABOUT_INFO">Application info</system:String>
+    <system:String x:Key="ABOUT_ACKNOWLEDGEMENTS">Acknowledgements</system:String>
+    <system:String x:Key="WEBSITE">Website</system:String>
+    <system:String x:Key="LICENSE">License</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -397,5 +397,9 @@
     <system:String x:Key="LOADING_SAVEGAMES">Caricamento salvataggi in corso...</system:String>
     <system:String x:Key="TOGGLE_FULLSCREEN">Commuta schermo intero (F11)</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Backup dei salvataggi in corso...</system:String>
+    <system:String x:Key="ABOUT_INFO">Informazioni applicazione</system:String>
+    <system:String x:Key="ABOUT_ACKNOWLEDGEMENTS">Riconoscimenti</system:String>
+    <system:String x:Key="WEBSITE">Sito web</system:String>
+    <system:String x:Key="LICENSE">Licenza</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher/Assets/AppStyles.axaml
+++ b/src/TombLauncher/Assets/AppStyles.axaml
@@ -363,13 +363,17 @@
     <Style Selector="Button.hyperlink">
         <Setter Property="Template">
             <ControlTemplate>
-                <TextBlock Text="{TemplateBinding Content}" Foreground="{DynamicResource AccentBrush}" TextDecorations="Underline">
-                </TextBlock>
+                <ContentPresenter Content="{TemplateBinding Content}"
+                                  TextElement.Foreground="{DynamicResource AccentBrush}" />
             </ControlTemplate>
         </Setter>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Cursor" Value="Hand"></Setter>
+    </Style>
+    <Style Selector="Button.hyperlink TextBlock">
+        <Setter Property="TextDecorations" Value="Underline" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
     </Style>
     
     <Style Selector=":is(Button).icon-only">
@@ -553,5 +557,20 @@
         <Setter Property="Padding" Value="12, 8"/>
         <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
+    </Style>
+    
+    <Style Selector="iconPacks|PackIconRemixIcon.stat-icon">
+        <Setter Property="Width" Value="20"/>
+        <Setter Property="Height" Value="20"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Foreground" Value="{DynamicResource MutedTextBrush}"/>
+        <Setter Property="Margin" Value="0,0,8,0"/>
+    </Style>
+    
+    <Style Selector="TextBlock.section-heading">
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="FontSize" Value="15"/>
+        <Setter Property="Margin" Value="0,8,0,2"/>
     </Style>
 </Styles>

--- a/src/TombLauncher/Extensions/ViewModelsServiceCollectionExtensions.cs
+++ b/src/TombLauncher/Extensions/ViewModelsServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using TombLauncher.Services;
 using TombLauncher.ViewModels;
 using TombLauncher.ViewModels.Pages;
 
@@ -9,19 +8,18 @@ public static class ViewModelsServiceCollectionExtensions
 {
     public static IServiceCollection AddViewModels(this IServiceCollection services)
     {
-        services.AddSingleton(sp =>
-            new WelcomePageViewModel(sp.GetRequiredService<WelcomePageService>()));
-        services.AddScoped<GameListViewModel>();
-        services.AddScoped<GameSearchViewModel>();
-        services.AddTransient<NewGameViewModel>();
-        services.AddSingleton<SettingsPageViewModel>();
-        services.AddSingleton<NotificationListViewModel>();
-        services.AddScoped<StatisticsPageViewModel>();
-        services.AddTransient<SavegameListViewModel>();
-        services.AddTransient<GameDetailsViewModel>();
-        services.AddTransient<LaunchOptionsViewModel>();
-        services.AddSingleton<MainWindowViewModel>();
-        services.AddTransient<LaunchOptionsViewModel>();
-        return services;
+        return services.AddSingleton<WelcomePageViewModel>()
+            .AddScoped<GameListViewModel>()
+            .AddScoped<GameSearchViewModel>()
+            .AddTransient<NewGameViewModel>()
+            .AddSingleton<SettingsPageViewModel>()
+            .AddSingleton<NotificationListViewModel>()
+            .AddScoped<StatisticsPageViewModel>()
+            .AddTransient<SavegameListViewModel>()
+            .AddTransient<GameDetailsViewModel>()
+            .AddTransient<LaunchOptionsViewModel>()
+            .AddSingleton<MainWindowViewModel>()
+            .AddTransient<LaunchOptionsViewModel>()
+            .AddSingleton<AboutPageViewModel>();
     }
 }

--- a/src/TombLauncher/ViewModels/MainWindowViewModel.cs
+++ b/src/TombLauncher/ViewModels/MainWindowViewModel.cs
@@ -23,8 +23,8 @@ public partial class MainWindowViewModel : WindowViewModelBase
         NotificationListViewModel = notificationListViewModel;
         _settingsProvider = settingsProvider;
         _platformSpecificFeatures = platformSpecificFeatures;
-        MenuItems = new ObservableCollection<MainMenuItemViewModel>()
-        {
+        MenuItems =
+        [
             new MainMenuItemViewModel()
             {
                 ToolTip = "WELCOME".GetLocalizedString(),
@@ -32,6 +32,7 @@ public partial class MainWindowViewModel : WindowViewModelBase
                 Text = "WELCOME".GetLocalizedString(),
                 ViewModelType = typeof(WelcomePageViewModel)
             },
+
             new MainMenuItemViewModel()
             {
                 ToolTip = "MY_MODS".GetLocalizedString(),
@@ -39,6 +40,7 @@ public partial class MainWindowViewModel : WindowViewModelBase
                 Text = "MY_MODS".GetLocalizedString(),
                 ViewModelType = typeof(GameListViewModel)
             },
+
             new MainMenuItemViewModel()
             {
                 ToolTip = "SEARCH".GetLocalizedString(),
@@ -46,6 +48,7 @@ public partial class MainWindowViewModel : WindowViewModelBase
                 Text = "SEARCH".GetLocalizedString(),
                 ViewModelType = typeof(GameSearchViewModel)
             },
+
             new MainMenuItemViewModel()
             {
                 ToolTip = "STATISTICS".GetLocalizedString(),
@@ -53,7 +56,7 @@ public partial class MainWindowViewModel : WindowViewModelBase
                 Text = "STATISTICS".GetLocalizedString(),
                 ViewModelType = typeof(StatisticsPageViewModel)
             }
-        };
+        ];
 
         SettingsItem = new MainMenuItemViewModel()
         {
@@ -77,6 +80,14 @@ public partial class MainWindowViewModel : WindowViewModelBase
             Icon = PackIconRemixIconKind.GlobalLine,
             Text = "OPEN_WEBSITE".GetLocalizedString(),
             Command = new RelayCommand(OpenWebsite)
+        };
+
+        AboutPageItem = new MainMenuItemViewModel()
+        {
+            ToolTip = "ABOUT_INFO".GetLocalizedString(),
+            Icon = PackIconRemixIconKind.InformationLine,
+            Text = "ABOUT_INFO".GetLocalizedString(),
+            ViewModelType = typeof(AboutPageViewModel),
         };
 
         Title = "Tomb Launcher";
@@ -117,7 +128,9 @@ public partial class MainWindowViewModel : WindowViewModelBase
     [ObservableProperty] private MainMenuItemViewModel _settingsItem;
     [ObservableProperty] private CommandViewModel _gitHubLinkItem;
     [ObservableProperty] private CommandViewModel _websiteLinkItem;
+    [ObservableProperty] private MainMenuItemViewModel _aboutPageItem;
     [ObservableProperty] private bool _isSettingsOpen;
+    [ObservableProperty] private bool _isAboutPageOpen;
 
     private void OpenGithub()
     {
@@ -154,6 +167,7 @@ public partial class MainWindowViewModel : WindowViewModelBase
         {
             if (value != SettingsItem)
                 IsSettingsOpen = false;
+            IsAboutPageOpen = false;
             SetProperty(ref field, value);
             if (value != null && !_isSyncingSelection)
             {
@@ -179,6 +193,14 @@ public partial class MainWindowViewModel : WindowViewModelBase
         await _navigationManager.NavigateTo(SettingsItem.ViewModelType!);
         SelectedMenuItem = SettingsItem;
         IsSettingsOpen = true;
+    }
+
+    [RelayCommand]
+    private async Task OpenAboutPage()
+    {
+        await _navigationManager.NavigateTo(AboutPageItem.ViewModelType!);
+        SelectedMenuItem = AboutPageItem;
+        IsAboutPageOpen = true;
     }
 
     [ObservableProperty] private WindowState _currentWindowState;

--- a/src/TombLauncher/ViewModels/PageViewModel.cs
+++ b/src/TombLauncher/ViewModels/PageViewModel.cs
@@ -23,6 +23,7 @@ public abstract partial class PageViewModel : ViewModelBase, INavigationTarget, 
     {
         return Task.CompletedTask;
     }
+    
     protected PageViewModel()
     {
         _progress = new Progress<PageBusyState>(state =>

--- a/src/TombLauncher/ViewModels/Pages/AboutPageViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/AboutPageViewModel.cs
@@ -1,0 +1,28 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TombLauncher.Core.PlatformSpecific;
+using TombLauncher.Services;
+using TombLauncher.Utils;
+
+namespace TombLauncher.ViewModels.Pages;
+
+public partial class AboutPageViewModel : PageViewModel
+{
+    private readonly IPlatformSpecificFeatures _platformSpecificFeatures;
+
+    public AboutPageViewModel(ISettingsProvider settingsProvider, IPlatformSpecificFeatures platformSpecificFeatures)
+    {
+        _platformSpecificFeatures = platformSpecificFeatures;
+        var coreSettings = settingsProvider.GetApplicationSettings();
+        ApplicationVersion = AppUtils.GetApplicationVersion();
+        GithubLink = coreSettings.GitHubLink;
+        WebsiteLink = coreSettings.WebsiteLink;
+    }
+    [ObservableProperty] private Version? _applicationVersion;
+    [ObservableProperty] private string _githubLink;
+    [ObservableProperty] private string _websiteLink;
+
+    [RelayCommand]
+    private void OpenLink(string url) => _platformSpecificFeatures.OpenUrl(url);
+}

--- a/src/TombLauncher/Views/MainWindow.axaml
+++ b/src/TombLauncher/Views/MainWindow.axaml
@@ -65,90 +65,26 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
-                <ListBoxItem Grid.Row="2"
-                             Content="{Binding AboutPageItem}"
-                             x:Name="AboutPageItem"
-                             IsSelected="{Binding IsAboutPageOpen}">
-                    <Interaction.Behaviors>
-                        <EventTriggerBehavior EventName="PointerReleased" 
-                                              SourceObject="AboutPageItem">
-                            <EventTriggerBehavior.Actions>
-                                <InvokeCommandAction Command="{Binding OpenAboutPageCommand}"/>
-                            </EventTriggerBehavior.Actions>
-                        </EventTriggerBehavior>
-                    </Interaction.Behaviors>
-                    <ListBoxItem.ContentTemplate>
-                        <DataTemplate DataType="{x:Type viewModels:MainMenuItemViewModel}">
-                            <StackPanel Spacing="20"
-                                        Orientation="Horizontal">
-                                <iconPacks:PackIconRemixIcon Kind="{Binding Icon}" />
-                                <TextBlock Text="{Binding Text}"/>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBoxItem.ContentTemplate>
-                </ListBoxItem>
-                <ListBoxItem Grid.Row="3" Content="{Binding WebsiteLinkItem}" x:Name="WebsiteLinkItem" 
-                             ToolTip.Tip="{Binding WebsiteLinkItem.Tooltip}">
-                    <Interaction.Behaviors>
-                        <EventTriggerBehavior EventName="PointerReleased" 
-                                              SourceObject="WebsiteLinkItem">
-                            <EventTriggerBehavior.Actions>
-                                <InvokeCommandAction Command="{Binding WebsiteLinkItem.Command}"/>
-                            </EventTriggerBehavior.Actions>
-                        </EventTriggerBehavior>
-                    </Interaction.Behaviors>
-                    <ListBoxItem.ContentTemplate>
-                        <DataTemplate DataType="{x:Type viewModels:CommandViewModel}">
-                            <StackPanel Spacing="20" 
-                                        Orientation="Horizontal">
-                                <iconPacks:PackIconRemixIcon Kind="{Binding Icon}" />
-                                <TextBlock Text="{Binding Text}"/>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBoxItem.ContentTemplate>
-                </ListBoxItem>
-                <ListBoxItem Grid.Row="4" Content="{Binding GitHubLinkItem}" x:Name="GitHubLinkItem" 
-                             ToolTip.Tip="{Binding GitHubLinkItem.Tooltip}">
-                    <Interaction.Behaviors>
-                        <EventTriggerBehavior EventName="PointerReleased" 
-                                              SourceObject="GitHubLinkItem">
-                            <EventTriggerBehavior.Actions>
-                                <InvokeCommandAction Command="{Binding GitHubLinkItem.Command}"/>
-                            </EventTriggerBehavior.Actions>
-                        </EventTriggerBehavior>
-                    </Interaction.Behaviors>
-                    <ListBoxItem.ContentTemplate>
-                        <DataTemplate DataType="{x:Type viewModels:CommandViewModel}">
-                            <StackPanel Spacing="20" 
-                                        Orientation="Horizontal">
-                                <iconPacks:PackIconRemixIcon Kind="{Binding Icon}" />
-                                <TextBlock Text="{Binding Text}"/>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBoxItem.ContentTemplate>
-                </ListBoxItem>
-                <ListBoxItem Grid.Row="5" 
-                             Content="{Binding SettingsItem}" 
-                             x:Name="SettingsItem" 
-                             IsSelected="{Binding IsSettingsOpen}">
-                    <Interaction.Behaviors>
-                        <EventTriggerBehavior EventName="PointerReleased" 
-                                              SourceObject="SettingsItem">
-                            <EventTriggerBehavior.Actions>
-                                <InvokeCommandAction Command="{Binding OpenSettingsCommand}"/>
-                            </EventTriggerBehavior.Actions>
-                        </EventTriggerBehavior>
-                    </Interaction.Behaviors>
-                    <ListBoxItem.ContentTemplate>
-                        <DataTemplate DataType="{x:Type viewModels:MainMenuItemViewModel}">
-                            <StackPanel Spacing="20" 
-                                        Orientation="Horizontal">
-                                <iconPacks:PackIconRemixIcon Kind="{Binding Icon}" />
-                                <TextBlock Text="{Binding Text}"/>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBoxItem.ContentTemplate>
-                </ListBoxItem>
+                <controls:SidebarNavigationItem Grid.Row="2"
+                                                Command="{Binding OpenAboutPageCommand}"
+                                                Icon="{Binding AboutPageItem.Icon}"
+                                                Text="{Binding AboutPageItem.Text}"
+                                                IsSelected="{Binding IsAboutPageOpen}" />
+                <controls:SidebarNavigationItem Grid.Row="3"
+                                                Command="{Binding WebsiteLinkItem.Command}"
+                                                Icon="{Binding WebsiteLinkItem.Icon}"
+                                                Text="{Binding WebsiteLinkItem.Text}"
+                                                ToolTip.Tip="{Binding WebsiteLinkItem.Tooltip}" />
+                <controls:SidebarNavigationItem Grid.Row="4"
+                                                Command="{Binding GitHubLinkItem.Command}"
+                                                Icon="{Binding GitHubLinkItem.Icon}"
+                                                Text="{Binding GitHubLinkItem.Text}"
+                                                ToolTip.Tip="{Binding GitHubLinkItem.Tooltip}" />
+                <controls:SidebarNavigationItem Grid.Row="5"
+                                                Command="{Binding OpenSettingsCommand}"
+                                                Icon="{Binding SettingsItem.Icon}"
+                                                Text="{Binding SettingsItem.Text}"
+                                                IsSelected="{Binding IsSettingsOpen}" />
             </Grid>
 
         </SplitView.Pane>

--- a/src/TombLauncher/Views/MainWindow.axaml
+++ b/src/TombLauncher/Views/MainWindow.axaml
@@ -37,6 +37,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <controls:IconButton Grid.Row="0" 
                                      Classes="icon-only"
@@ -64,7 +65,29 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
-                <ListBoxItem Grid.Row="2" Content="{Binding WebsiteLinkItem}" x:Name="WebsiteLinkItem" 
+                <ListBoxItem Grid.Row="2"
+                             Content="{Binding AboutPageItem}"
+                             x:Name="AboutPageItem"
+                             IsSelected="{Binding IsAboutPageOpen}">
+                    <Interaction.Behaviors>
+                        <EventTriggerBehavior EventName="PointerReleased" 
+                                              SourceObject="AboutPageItem">
+                            <EventTriggerBehavior.Actions>
+                                <InvokeCommandAction Command="{Binding OpenAboutPageCommand}"/>
+                            </EventTriggerBehavior.Actions>
+                        </EventTriggerBehavior>
+                    </Interaction.Behaviors>
+                    <ListBoxItem.ContentTemplate>
+                        <DataTemplate DataType="{x:Type viewModels:MainMenuItemViewModel}">
+                            <StackPanel Spacing="20"
+                                        Orientation="Horizontal">
+                                <iconPacks:PackIconRemixIcon Kind="{Binding Icon}" />
+                                <TextBlock Text="{Binding Text}"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBoxItem.ContentTemplate>
+                </ListBoxItem>
+                <ListBoxItem Grid.Row="3" Content="{Binding WebsiteLinkItem}" x:Name="WebsiteLinkItem" 
                              ToolTip.Tip="{Binding WebsiteLinkItem.Tooltip}">
                     <Interaction.Behaviors>
                         <EventTriggerBehavior EventName="PointerReleased" 
@@ -84,7 +107,7 @@
                         </DataTemplate>
                     </ListBoxItem.ContentTemplate>
                 </ListBoxItem>
-                <ListBoxItem Grid.Row="3" Content="{Binding GitHubLinkItem}" x:Name="GitHubLinkItem" 
+                <ListBoxItem Grid.Row="4" Content="{Binding GitHubLinkItem}" x:Name="GitHubLinkItem" 
                              ToolTip.Tip="{Binding GitHubLinkItem.Tooltip}">
                     <Interaction.Behaviors>
                         <EventTriggerBehavior EventName="PointerReleased" 
@@ -104,7 +127,7 @@
                         </DataTemplate>
                     </ListBoxItem.ContentTemplate>
                 </ListBoxItem>
-                <ListBoxItem Grid.Row="4" 
+                <ListBoxItem Grid.Row="5" 
                              Content="{Binding SettingsItem}" 
                              x:Name="SettingsItem" 
                              IsSelected="{Binding IsSettingsOpen}">

--- a/src/TombLauncher/Views/Pages/AboutPageView.axaml
+++ b/src/TombLauncher/Views/Pages/AboutPageView.axaml
@@ -1,0 +1,90 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:TombLauncher.Controls;assembly=TombLauncher.Controls"
+             xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
+             xmlns:localization="clr-namespace:TombLauncher.Localization;assembly=TombLauncher.Localization"
+             xmlns:pages="clr-namespace:TombLauncher.ViewModels.Pages"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="TombLauncher.Views.Pages.AboutPageView"
+             x:DataType="pages:AboutPageViewModel">
+    <Design.DataContext>
+        <pages:AboutPageViewModel />
+    </Design.DataContext>
+    <UserControl.Styles>
+        <Style Selector="iconPacks|PackIconRemixIcon">
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+    </UserControl.Styles>
+    <ScrollViewer>
+        <StackPanel Margin="16">
+            <controls:HeroSection />
+
+            <Border Classes="card-background" CornerRadius="8" Padding="16">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" MinHeight="36" />
+                        <RowDefinition Height="Auto" MinHeight="36" />
+                        <RowDefinition Height="Auto" MinHeight="36" />
+                        <RowDefinition Height="Auto" MinHeight="36" />
+                        <RowDefinition Height="Auto" MinHeight="36" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="32" />
+                        <ColumnDefinition Width="Auto" MinWidth="180" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Classes="section-heading"
+                               Text="{localization:Translate ABOUT_INFO, Casing=Upper}">
+                    </TextBlock>
+
+                    <iconPacks:PackIconRemixIcon Grid.Row="1" Grid.Column="0" Kind="InformationLine" />
+                    <iconPacks:PackIconRemixIcon Grid.Row="2" Grid.Column="0" Kind="GithubFill" Classes="stat-icon" />
+                    <iconPacks:PackIconRemixIcon Grid.Row="3" Grid.Column="0" Kind="GlobalLine" Classes="stat-icon" />
+                    <iconPacks:PackIconRemixIcon Grid.Row="4" Grid.Column="0" Kind="FilePaper2Line" Classes="stat-icon" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="1" Classes="text-muted" Margin="0, 0, 8, 0"
+                               Text="{localization:Translate APPLICATION_VERSION}" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Classes="text-muted" Margin="0, 0, 8, 0" Text="Github" />
+                    <TextBlock Grid.Row="3" Grid.Column="1" Classes="text-muted" Margin="0, 0, 8, 0"
+                               Text="{localization:Translate WEBSITE}" />
+                    <TextBlock Grid.Row="4" Grid.Column="1" Classes="text-muted" Margin="0, 0, 8, 0"
+                               Text="{localization:Translate LICENSE}" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding ApplicationVersion}" FontWeight="Medium" />
+                    <Button Classes="hyperlink" Grid.Row="2" Grid.Column="2" FontWeight="Medium"
+                            Command="{Binding OpenLinkCommand}"
+                            CommandParameter="{Binding GithubLink}">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock FontWeight="Medium" Text="{Binding GithubLink}" VerticalAlignment="Center" />
+                            <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Margin="8, 0, 0, 0" Width="16"
+                                                         Height="16" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="hyperlink" Grid.Row="3" Grid.Column="2" FontWeight="Medium"
+                            Command="{Binding OpenLinkCommand}"
+                            CommandParameter="{Binding WebsiteLink}">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock FontWeight="Medium" Text="{Binding WebsiteLink}" VerticalAlignment="Center" />
+                            <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Margin="8, 0, 0, 0" Width="16"
+                                                         Height="16" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <TextBlock Grid.Row="4" Grid.Column="2" FontWeight="Medium" Text="MIT" />
+                </Grid>
+            </Border>
+
+            <Border Classes="card-background" CornerRadius="8" Padding="16" Margin="0, 24">
+                <StackPanel>
+                    <TextBlock Classes="section-heading"
+                               Text="{localization:Translate ABOUT_ACKNOWLEDGEMENTS, Casing=Upper}" />
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/TombLauncher/Views/Pages/AboutPageView.axaml
+++ b/src/TombLauncher/Views/Pages/AboutPageView.axaml
@@ -79,10 +79,147 @@
                 </Grid>
             </Border>
 
-            <Border Classes="card-background" CornerRadius="8" Padding="16" Margin="0, 24">
-                <StackPanel>
+            <Border Classes="card-background" CornerRadius="8" Padding="16" Margin="0,24">
+                <StackPanel Spacing="4">
                     <TextBlock Classes="section-heading"
                                Text="{localization:Translate ABOUT_ACKNOWLEDGEMENTS, Casing=Upper}" />
+
+                    <TextBlock Margin="0,8,0,2" FontWeight="SemiBold" Text="Inspiration" />
+                    <WrapPanel>
+                        <TextBlock Text="Heavily inspired by " />
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://github.com/nstlaurent/DoomLauncher">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="Doom Launcher" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" by hobomaster22" />
+                    </WrapPanel>
+
+                    <TextBlock Margin="0,8,0,2" FontWeight="SemiBold" Text="Fonts &amp; Icons" />
+                    <WrapPanel>
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://github.com/lipis/flag-icons">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="Lipis Flag Icons" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" — flag icons" />
+                    </WrapPanel>
+                    <WrapPanel>
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://www.dafont.com/navin-adchariyavanich.d5775">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="Tomb Raider Font" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" by Navin_Ad" />
+                    </WrapPanel>
+                    <WrapPanel>
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://fonts.google.com/specimen/Figtree">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="Figtree" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" by Erik Kennedy" />
+                    </WrapPanel>
+                    <WrapPanel>
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://fonts.google.com/specimen/Spectral">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="Spectral" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" by Production Type" />
+                    </WrapPanel>
+
+                    <TextBlock Margin="0,8,0,2" FontWeight="SemiBold" Text="Community sites" />
+                    <Button Classes="hyperlink"
+                            Command="{Binding OpenLinkCommand}"
+                            CommandParameter="https://www.trle.net">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <TextBlock Text="TRLE.net" />
+                            <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                        </StackPanel>
+                    </Button>
+                    <WrapPanel>
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://trcustoms.org">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="TRCustoms.org" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" — special thanks to " />
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://github.com/rr-">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="dash" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" for granting access to the TRCustoms API" />
+                    </WrapPanel>
+                    <Button Classes="hyperlink"
+                            Command="{Binding OpenLinkCommand}"
+                            CommandParameter="https://aspidetr.com">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <TextBlock Text="AspideTR.com" />
+                            <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                        </StackPanel>
+                    </Button>
+
+                    <TextBlock Margin="0,8,0,2" FontWeight="SemiBold" Text="Special thanks" />
+                    <WrapPanel>
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://lostartefacts.dev/">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="TRX team" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" — particularly " />
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://github.com/rr-">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="dash" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" and " />
+                        <Button Classes="hyperlink"
+                                Command="{Binding OpenLinkCommand}"
+                                CommandParameter="https://github.com/lahm86">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="lahm86" />
+                                <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                            </StackPanel>
+                        </Button>
+                        <TextBlock Text=" for answering questions about their engine" />
+                    </WrapPanel>
+                    <Button Classes="hyperlink"
+                            Command="{Binding OpenLinkCommand}"
+                            CommandParameter="https://tombengine.com/">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <TextBlock Text="Tomb Engine team" />
+                            <iconPacks:PackIconRemixIcon Kind="ExternalLinkFill" Width="12" Height="12" />
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
             </Border>
         </StackPanel>

--- a/src/TombLauncher/Views/Pages/AboutPageView.axaml.cs
+++ b/src/TombLauncher/Views/Pages/AboutPageView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace TombLauncher.Views.Pages;
+
+public partial class AboutPageView : UserControl
+{
+    public AboutPageView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/TombLauncher/Views/Pages/StatisticsPageView.axaml
+++ b/src/TombLauncher/Views/Pages/StatisticsPageView.axaml
@@ -17,19 +17,6 @@
         <Style Selector="TextBlock">
             <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
-        <Style Selector="TextBlock.section-heading">
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="FontSize" Value="15"/>
-            <Setter Property="Margin" Value="0,8,0,2"/>
-        </Style>
-        <Style Selector="iconPacks|PackIconRemixIcon.stat-icon">
-            <Setter Property="Width" Value="20"/>
-            <Setter Property="Height" Value="20"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="Foreground" Value="{DynamicResource MutedTextBrush}"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
-        </Style>
     </UserControl.Styles>
 
     <Interaction.Behaviors>

--- a/src/TombLauncher/Views/Pages/WelcomePageView.axaml
+++ b/src/TombLauncher/Views/Pages/WelcomePageView.axaml
@@ -25,12 +25,7 @@
     <ScrollViewer>
         <StackPanel Margin="16">
             <!-- Hero Section -->
-            <TextBlock Classes="h1" Text="TOMB LAUNCHER" Margin="0,8,0,4" />
-            <TextBlock Text="{loc:Translate WELCOME_SUBTITLE}"
-                       HorizontalAlignment="Center"
-                       Foreground="{DynamicResource SecondaryBrush}"
-                       FontSize="14"
-                       Margin="0,0,0,16" />
+            <controls:HeroSection />
 
             <!-- Widgets -->
             <welcomePage:QuickStatsWidget />


### PR DESCRIPTION
- Add AboutPageView with app info card (version, GitHub link, website, license)
- Add acknowledgements card with credits for inspiration, fonts & icons,
  community sites, and special thanks
- Extract reusable SidebarNavigationItem control to replace duplicated
  ListBoxItem blocks in the sidebar
- Add HeroSection control shared between WelcomePageView and AboutPageView
- Promote stat-icon and section-heading styles to global AppStyles
- Update Button.hyperlink template to support complex content via ContentPresenter

Can close.