### PR TITLE
feat(platform): add game support matrix (#89)

### DIFF
--- a/src/TombLauncher.Contracts/Enums/EngineSupportState.cs
+++ b/src/TombLauncher.Contracts/Enums/EngineSupportState.cs
@@ -1,0 +1,9 @@
+namespace TombLauncher.Contracts.Enums;
+
+public enum EngineSupportState
+{
+    NoSupport,
+    SupportedWithCompatibilityLayer,
+    NativePatchingAvailable,
+    FullSupport
+}

--- a/src/TombLauncher.Contracts/SupportMatrix/ISupportMatrix.cs
+++ b/src/TombLauncher.Contracts/SupportMatrix/ISupportMatrix.cs
@@ -1,0 +1,9 @@
+using TombLauncher.Contracts.Enums;
+
+namespace TombLauncher.Contracts.SupportMatrix;
+
+public interface ISupportMatrix
+{
+    IReadOnlyDictionary<GameEngine, EngineSupportState> Matrix { get; }
+    EngineSupportState GetEngineSupportState(GameEngine engine) => Matrix.GetValueOrDefault(engine, EngineSupportState.NoSupport);
+}

--- a/src/TombLauncher.Contracts/SupportMatrix/ISupportMatrix.cs
+++ b/src/TombLauncher.Contracts/SupportMatrix/ISupportMatrix.cs
@@ -5,5 +5,12 @@ namespace TombLauncher.Contracts.SupportMatrix;
 public interface ISupportMatrix
 {
     IReadOnlyDictionary<GameEngine, EngineSupportState> Matrix { get; }
-    EngineSupportState GetEngineSupportState(GameEngine engine) => Matrix.GetValueOrDefault(engine, EngineSupportState.NoSupport);
+
+    EngineSupportState GetEngineSupportState(GameEngine? engine)
+    {
+        if (engine == null)
+            return EngineSupportState.NoSupport;
+        
+        return Matrix.GetValueOrDefault(engine.Value, EngineSupportState.NoSupport);
+    }
 }

--- a/src/TombLauncher.Core/PlatformSpecific/IPlatformSpecificFeatures.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/IPlatformSpecificFeatures.cs
@@ -1,3 +1,4 @@
+using TombLauncher.Contracts.SupportMatrix;
 using TombLauncher.Core.Dtos;
 
 namespace TombLauncher.Core.PlatformSpecific;
@@ -19,4 +20,5 @@ public interface IPlatformSpecificFeatures
     string? GetWineVersion(string winePath);
     List<ProtonInstallationDto> FindAvailableProtonInstallations();
     string? GetProtonVersion(string protonPath);
+    ISupportMatrix SupportMatrix { get; }
 }

--- a/src/TombLauncher.Core/PlatformSpecific/LinuxPlatformSpecificFeatures.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/LinuxPlatformSpecificFeatures.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using TombLauncher.Contracts.SupportMatrix;
 using TombLauncher.Core.Dtos;
+using TombLauncher.Core.PlatformSpecific.SupportMatrix;
 
 namespace TombLauncher.Core.PlatformSpecific;
 
@@ -187,4 +189,6 @@ public class LinuxPlatformSpecificFeatures : IPlatformSpecificFeatures
         try { return File.ReadAllText(versionFile).Trim(); }
         catch { return null; }
     }
+
+    public ISupportMatrix SupportMatrix { get; } = new LinuxSupportMatrix();
 }

--- a/src/TombLauncher.Core/PlatformSpecific/SupportMatrix/LinuxSupportMatrix.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/SupportMatrix/LinuxSupportMatrix.cs
@@ -1,0 +1,28 @@
+using TombLauncher.Contracts.Enums;
+using TombLauncher.Contracts.SupportMatrix;
+
+namespace TombLauncher.Core.PlatformSpecific.SupportMatrix;
+
+public class LinuxSupportMatrix : ISupportMatrix
+{
+    public LinuxSupportMatrix()
+    {
+        Matrix = new Dictionary<GameEngine, EngineSupportState>()
+        {
+            { GameEngine.Unknown, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider1, EngineSupportState.SupportedWithCompatibilityLayer },
+            { GameEngine.TombRaider1Dos, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider2, EngineSupportState.SupportedWithCompatibilityLayer },
+            { GameEngine.TombRaider3, EngineSupportState.SupportedWithCompatibilityLayer },
+            { GameEngine.TombRaider4, EngineSupportState.SupportedWithCompatibilityLayer },
+            { GameEngine.TombRaider5, EngineSupportState.SupportedWithCompatibilityLayer },
+            { GameEngine.Ten, EngineSupportState.NoSupport },
+            { GameEngine.Tr1x, EngineSupportState.SupportedWithCompatibilityLayer },
+            { GameEngine.Tr2x, EngineSupportState.SupportedWithCompatibilityLayer },
+            { GameEngine.TombAti, EngineSupportState.SupportedWithCompatibilityLayer },
+            { GameEngine.Tomb2Main, EngineSupportState.SupportedWithCompatibilityLayer },
+            { GameEngine.Tomb3CommunityEdition, EngineSupportState.SupportedWithCompatibilityLayer }
+        };
+    }
+    public IReadOnlyDictionary<GameEngine, EngineSupportState> Matrix { get; }
+}

--- a/src/TombLauncher.Core/PlatformSpecific/SupportMatrix/MacOsSupportMatrix.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/SupportMatrix/MacOsSupportMatrix.cs
@@ -1,0 +1,28 @@
+using TombLauncher.Contracts.Enums;
+using TombLauncher.Contracts.SupportMatrix;
+
+namespace TombLauncher.Core.PlatformSpecific.SupportMatrix;
+
+public class MacOsSupportMatrix : ISupportMatrix
+{
+    public MacOsSupportMatrix()
+    {
+        Matrix = new Dictionary<GameEngine, EngineSupportState>()
+        {
+            { GameEngine.Unknown, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider1, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider1Dos, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider2, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider3, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider4, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider5, EngineSupportState.NoSupport },
+            { GameEngine.Ten, EngineSupportState.NoSupport },
+            { GameEngine.Tr1x, EngineSupportState.NoSupport },
+            { GameEngine.Tr2x, EngineSupportState.NoSupport },
+            { GameEngine.TombAti, EngineSupportState.NoSupport },
+            { GameEngine.Tomb2Main, EngineSupportState.NoSupport },
+            { GameEngine.Tomb3CommunityEdition, EngineSupportState.NoSupport }
+        };
+    }
+    public IReadOnlyDictionary<GameEngine, EngineSupportState> Matrix { get; }
+}

--- a/src/TombLauncher.Core/PlatformSpecific/SupportMatrix/WindowsSupportMatrix.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/SupportMatrix/WindowsSupportMatrix.cs
@@ -1,0 +1,28 @@
+using TombLauncher.Contracts.Enums;
+using TombLauncher.Contracts.SupportMatrix;
+
+namespace TombLauncher.Core.PlatformSpecific.SupportMatrix;
+
+public class WindowsSupportMatrix : ISupportMatrix
+{
+    public WindowsSupportMatrix()
+    {
+        Matrix = new Dictionary<GameEngine, EngineSupportState>()
+        {
+            { GameEngine.Unknown, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider1, EngineSupportState.FullSupport },
+            { GameEngine.TombRaider1Dos, EngineSupportState.NoSupport },
+            { GameEngine.TombRaider2, EngineSupportState.FullSupport },
+            { GameEngine.TombRaider3, EngineSupportState.FullSupport },
+            { GameEngine.TombRaider4, EngineSupportState.FullSupport },
+            { GameEngine.TombRaider5, EngineSupportState.FullSupport },
+            { GameEngine.Ten, EngineSupportState.FullSupport },
+            { GameEngine.Tr1x, EngineSupportState.FullSupport },
+            { GameEngine.Tr2x, EngineSupportState.FullSupport },
+            { GameEngine.TombAti, EngineSupportState.FullSupport },
+            { GameEngine.Tomb2Main, EngineSupportState.FullSupport },
+            { GameEngine.Tomb3CommunityEdition, EngineSupportState.FullSupport }
+        };
+    }
+    public IReadOnlyDictionary<GameEngine, EngineSupportState> Matrix { get; }
+}

--- a/src/TombLauncher.Core/PlatformSpecific/WindowsPlatformSpecificFeatures.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/WindowsPlatformSpecificFeatures.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Reflection;
+using TombLauncher.Contracts.SupportMatrix;
 using TombLauncher.Core.Dtos;
+using TombLauncher.Core.PlatformSpecific.SupportMatrix;
 
 namespace TombLauncher.Core.PlatformSpecific;
 
@@ -66,4 +68,5 @@ public class WindowsPlatformSpecificFeatures : IPlatformSpecificFeatures
     public string? GetWineVersion(string winePath) => null;
     public List<ProtonInstallationDto> FindAvailableProtonInstallations() => [];
     public string? GetProtonVersion(string protonPath) => null;
+    public ISupportMatrix SupportMatrix { get; } = new WindowsSupportMatrix();
 }

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -456,5 +456,9 @@
     <system:String x:Key="KB_SCHEMA_TOO_NEW">Remote knowledge base requires a newer version of TombLauncher</system:String>
     <system:String x:Key="KB_INTEGRITY_ERROR">Knowledge base download failed: integrity check error</system:String>
     <system:String x:Key="KB_UPDATE_FAILED">Knowledge base update failed: {0}</system:String>
+    <system:String x:Key="NATIVE_SUPPORT">This level runs natively on the current operating system.</system:String>
+    <system:String x:Key="SUPPORTED_WITH_COMPATIBILITY_LAYER">This level runs via a compatibility layer.</system:String>
+    <system:String x:Key="SUPPORTED_NATIVE_PATCHING_AVAILABLE">This level runs via a compatibility layer, but a patch is available to run it natively.</system:String>
+    <system:String x:Key="NO_SUPPORT">This level does not run on the current operating system.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -456,5 +456,9 @@
     <system:String x:Key="KB_SCHEMA_TOO_NEW">La knowledge base remota richiede una versione più recente di TombLauncher</system:String>
     <system:String x:Key="KB_INTEGRITY_ERROR">Download della knowledge base fallito: errore di integrità</system:String>
     <system:String x:Key="KB_UPDATE_FAILED">Aggiornamento della knowledge base fallito: {0}</system:String>
+    <system:String x:Key="NATIVE_SUPPORT">Questo livello gira nativamente sul sistema operativo attuale.</system:String>
+    <system:String x:Key="SUPPORTED_WITH_COMPATIBILITY_LAYER">Questo livello gira tramite layer di compatibilità.</system:String>
+    <system:String x:Key="SUPPORTED_NATIVE_PATCHING_AVAILABLE">Questo livello gira tramite layer di compatibilità, ma è disponibile una patch per eseguirlo nativamente.</system:String>
+    <system:String x:Key="NO_SUPPORT">Questo livello non gira sul sistema operativo attuale.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher/Assets/Converters.axaml
+++ b/src/TombLauncher/Assets/Converters.axaml
@@ -18,6 +18,7 @@
         <valueConverters:EnumIsNotDefaultConverter          x:Key="EnumIsNotDefaultConverter" />
         <valueConverters:AiBackendTypeToIconConverter       x:Key="AiBackendTypeToIconConverter" />
         <valueConverters:ServiceCheckStatusToColorConverter x:Key="ServiceCheckStatusToColorConverter" />
+        <valueConverters:EngineSupportStateToIconConverter  x:Key="EngineSupportStateToIconConverter" />
 
         <!-- ── Date / time ── -->
         <valueConverters:TimeSpanToHumanReadableStringConverter x:Key="TimeSpanToHumanReadableStringConverter" />

--- a/src/TombLauncher/Assets/Converters.axaml
+++ b/src/TombLauncher/Assets/Converters.axaml
@@ -14,11 +14,12 @@
         <valueConverters:CollectionToVisibilityConverter x:Key="CollectionNotEmptyToVisibilityConverter" Invert="True" />
 
         <!-- ── Enums ── -->
-        <valueConverters:EnumToDescriptionConverter         x:Key="EnumToDescriptionConverter" />
-        <valueConverters:EnumIsNotDefaultConverter          x:Key="EnumIsNotDefaultConverter" />
-        <valueConverters:AiBackendTypeToIconConverter       x:Key="AiBackendTypeToIconConverter" />
-        <valueConverters:ServiceCheckStatusToColorConverter x:Key="ServiceCheckStatusToColorConverter" />
-        <valueConverters:EngineSupportStateToIconConverter  x:Key="EngineSupportStateToIconConverter" />
+        <valueConverters:EnumToDescriptionConverter           x:Key="EnumToDescriptionConverter" />
+        <valueConverters:EnumIsNotDefaultConverter            x:Key="EnumIsNotDefaultConverter" />
+        <valueConverters:AiBackendTypeToIconConverter         x:Key="AiBackendTypeToIconConverter" />
+        <valueConverters:ServiceCheckStatusToColorConverter   x:Key="ServiceCheckStatusToColorConverter" />
+        <valueConverters:EngineSupportStateToIconConverter    x:Key="EngineSupportStateToIconConverter" />
+        <valueConverters:EngineSupportStateToTooltipConverter x:Key="EngineSupportStateToTooltipConverter" />
 
         <!-- ── Date / time ── -->
         <valueConverters:TimeSpanToHumanReadableStringConverter x:Key="TimeSpanToHumanReadableStringConverter" />

--- a/src/TombLauncher/Services/GameDetailsService.cs
+++ b/src/TombLauncher/Services/GameDetailsService.cs
@@ -138,4 +138,7 @@ public class GameDetailsService : IViewService
     {
         return _settingsProvider.GetAiCoreSettings().IsEnabled && vm?.IsInstalled == true;
     }
+
+    public EngineSupportState GetEngineSupportState(GameMetadataViewModel? vm) =>
+        _platformSpecificFeatures.SupportMatrix.GetEngineSupportState(vm?.GameEngine);
 }

--- a/src/TombLauncher/ValueConverters/EngineSupportStateToIconConverter.cs
+++ b/src/TombLauncher/ValueConverters/EngineSupportStateToIconConverter.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using IconPacks.Avalonia.RemixIcon;
+using TombLauncher.Contracts.Enums;
+
+namespace TombLauncher.ValueConverters;
+
+public class EngineSupportStateToIconConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is EngineSupportState engineSupportState)
+        {
+            return engineSupportState switch
+            {
+                EngineSupportState.NativePatchingAvailable => PackIconRemixIconKind.WrenchFill,
+                EngineSupportState.SupportedWithCompatibilityLayer => PackIconRemixIconKind.ToolsFill,
+                EngineSupportState.FullSupport => PackIconRemixIconKind.CheckFill,
+                _ => PackIconRemixIconKind.CloseCircleFill
+            };
+        }
+
+        return null;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/TombLauncher/ValueConverters/EngineSupportStateToTooltipConverter.cs
+++ b/src/TombLauncher/ValueConverters/EngineSupportStateToTooltipConverter.cs
@@ -1,0 +1,6 @@
+namespace TombLauncher.ValueConverters;
+
+public class EngineSupportStateToTooltipConverter
+{
+    
+}

--- a/src/TombLauncher/ValueConverters/EngineSupportStateToTooltipConverter.cs
+++ b/src/TombLauncher/ValueConverters/EngineSupportStateToTooltipConverter.cs
@@ -1,6 +1,31 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using TombLauncher.Contracts.Enums;
+using TombLauncher.Localization.Extensions;
+
 namespace TombLauncher.ValueConverters;
 
-public class EngineSupportStateToTooltipConverter
+public class EngineSupportStateToTooltipConverter : IValueConverter
 {
-    
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is EngineSupportState engineSupportState)
+        {
+            return engineSupportState switch
+            {
+                EngineSupportState.NativePatchingAvailable => "SUPPORTED_NATIVE_PATCHING_AVAILABLE".GetLocalizedString(),
+                EngineSupportState.SupportedWithCompatibilityLayer => "SUPPORTED_WITH_COMPATIBILITY_LAYER".GetLocalizedString(),
+                EngineSupportState.FullSupport => "NATIVE_SUPPORT".GetLocalizedString(),
+                _ => "NO_SUPPORT".GetLocalizedString()
+            };
+        }
+
+        return null;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
 }

--- a/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
@@ -27,7 +27,12 @@ public partial class GameDetailsViewModel : PageViewModel
 
     [ObservableProperty] private ObservableCollection<CommandViewModel> _setupCommands = [];
     [ObservableProperty] private ObservableCollection<FileInfo> _documentationFiles = [];
-    [ObservableProperty][NotifyPropertyChangedFor(nameof(CanOpenChat))] private GameWithStatsViewModel _game = null!;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanOpenChat))]
+    [NotifyPropertyChangedFor(nameof(EngineSupportState))]
+    private GameWithStatsViewModel _game = null!;
+
     [ObservableProperty] private int _descriptionFontSize = 18;
     [ObservableProperty] private ObservableCollection<GameLinkViewModel> _walkthroughLinks = [];
     public bool CanOpenChat => _gameDetailsService.CanOpenChat(Game?.GameMetadata);
@@ -118,4 +123,6 @@ public partial class GameDetailsViewModel : PageViewModel
 
         SetupCommands = setupCommands;
     }
+
+    public EngineSupportState EngineSupportState => _gameDetailsService.GetEngineSupportState(Game?.GameMetadata);
 }

--- a/src/TombLauncher/Views/GameBar.axaml
+++ b/src/TombLauncher/Views/GameBar.axaml
@@ -173,7 +173,8 @@
                                              IsVisible="{Binding Game.GameMetadata.IsInstalled}"
                                              Classes.danger="{Binding EngineSupportState,
                                                  Converter={x:Static ObjectConverters.Equal},
-                                                 ConverterParameter={x:Static enums:EngineSupportState.NoSupport}}" />
+                                                 ConverterParameter={x:Static enums:EngineSupportState.NoSupport}}"
+                                             ToolTip.Tip="{Binding EngineSupportState, Converter={StaticResource EngineSupportStateToTooltipConverter}}"/>
 
                 <!-- Last played: label + date, grouped together -->
                 <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center"

--- a/src/TombLauncher/Views/GameBar.axaml
+++ b/src/TombLauncher/Views/GameBar.axaml
@@ -9,6 +9,7 @@
              xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
              xmlns:system="clr-namespace:System;assembly=System.Runtime"
              xmlns:io="clr-namespace:System.IO;assembly=System.Runtime"
+             xmlns:enums="clr-namespace:TombLauncher.Contracts.Enums;assembly=TombLauncher.Contracts"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="80"
              x:DataType="pages:GameDetailsViewModel"
              x:Class="TombLauncher.Views.GameBar"
@@ -164,6 +165,15 @@
                                              Background="Transparent"
                                              IsVisible="{Binding Game.GameMetadata.IsFavourite}"
                                              ToolTip.Tip="{loc:Translate FAVOURITE}" />
+                
+                <iconPacks:PackIconRemixIcon Kind="{Binding EngineSupportState, Converter={StaticResource EngineSupportStateToIconConverter}}"
+                                             Width="22" Height="22"
+                                             VerticalAlignment="Center"
+                                             Background="Transparent"
+                                             IsVisible="{Binding Game.GameMetadata.IsInstalled}"
+                                             Classes.danger="{Binding EngineSupportState,
+                                                 Converter={x:Static ObjectConverters.Equal},
+                                                 ConverterParameter={x:Static enums:EngineSupportState.NoSupport}}" />
 
                 <!-- Last played: label + date, grouped together -->
                 <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center"


### PR DESCRIPTION
Introduces a per-OS engine support matrix to IPlatformSpecificFeatures:

- Add EngineSupportState enum (NoSupport, SupportedWithCompatibilityLayer,
  NativePatchingAvailable, FullSupport)
- Add ISupportMatrix interface with IReadOnlyDictionary<GameEngine, EngineSupportState>
- Implement LinuxSupportMatrix, WindowsSupportMatrix, MacOsSupportMatrix
- Wire ISupportMatrix into IPlatformSpecificFeatures and both platform implementations
- Expose EngineSupportState in GameDetailsViewModel via GameDetailsService
- Show a status icon in GameBar with danger class for unsupported engines
- Add EngineSupportStateToIconConverter and EngineSupportStateToTooltipConverter
- Add localization strings for all four states (en-US, it-IT)