### PR TITLE
fix(launch-options): populate executables correctly and handle IO errors

### DIFF
--- a/src/TombLauncher.Core/PlatformSpecific/LinuxPlatformSpecificFeatures.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/LinuxPlatformSpecificFeatures.cs
@@ -26,21 +26,8 @@ public class LinuxPlatformSpecificFeatures : IPlatformSpecificFeatures
             MatchCasing = MatchCasing.CaseInsensitive,
             IgnoreInaccessible = true,
             RecurseSubdirectories = true,
-            ReturnSpecialDirectories = false
-        };
-    }
-
-    public ProcessStartInfo GetGameLaunchStartInfo(string executableFileNameOnly, string? arguments, string compatibilityExecutable,
-        string workingDirectory)
-    {
-        arguments = executableFileNameOnly + " " + (arguments ?? "");
-        return new ProcessStartInfo(compatibilityExecutable)
-        {
-            Arguments = arguments,
-            WorkingDirectory = workingDirectory,
-            UseShellExecute = false,
-            RedirectStandardError = true,
-            RedirectStandardOutput = true
+            ReturnSpecialDirectories = false,
+            AttributesToSkip = FileAttributes.ReparsePoint
         };
     }
 

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -197,6 +197,7 @@
     <system:String x:Key="AI_TROUBLESHOOTING">Ask Laura for help</system:String>
     <system:String x:Key="LAUNCH_OPTIONS">Launch options</system:String>
     <system:String x:Key="LAUNCH_OPTIONS_TOOLTIP">Allows you to set this game's engine type, the executable to run to launch it, and the command to launch setup.</system:String>
+    <system:String x:Key="LAUNCH_OPTIONS_EXECUTABLE_READ_ERROR">An error occurred while reading the game's install directory. The launch options page could not be opened.</system:String>
     <system:String x:Key="ENGINE_TYPE">Engine type</system:String>
     <system:String x:Key="AUTO_DETECT">Auto detect</system:String>
     <system:String x:Key="GAME_EXECUTABLE">Game executable</system:String>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -197,6 +197,7 @@
     <system:String x:Key="AI_TROUBLESHOOTING">Chiedi aiuto a Laura</system:String>
     <system:String x:Key="LAUNCH_OPTIONS">Opzioni di avvio</system:String>
     <system:String x:Key="LAUNCH_OPTIONS_TOOLTIP">Ti consente di impostare il tipo di motore di questo gioco, l'eseguibile da usare per avviarlo, e il comando per avviare il setup.</system:String>
+    <system:String x:Key="LAUNCH_OPTIONS_EXECUTABLE_READ_ERROR">Si è verificato un errore durante la lettura della directory di installazione del gioco. Impossibile aprire la pagina delle opzioni di avvio.</system:String>
     <system:String x:Key="ENGINE_TYPE">Tipo di motore</system:String>
     <system:String x:Key="AUTO_DETECT">Rileva automaticamente</system:String>
     <system:String x:Key="GAME_EXECUTABLE">Eseguibile</system:String>

--- a/src/TombLauncher/Services/LaunchOptionsService.cs
+++ b/src/TombLauncher/Services/LaunchOptionsService.cs
@@ -3,9 +3,12 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using JamSoft.AvaloniaUI.Dialogs.MsgBox;
 using Microsoft.Extensions.Logging;
 using TombLauncher.Core.Extensions;
+using TombLauncher.Core.PlatformSpecific;
 using TombLauncher.Data.Database.Services;
+using TombLauncher.Extensions;
 using TombLauncher.Installers;
 using TombLauncher.Localization.Extensions;
 using TombLauncher.Mappers;
@@ -21,13 +24,15 @@ public class LaunchOptionsService : IViewService
         GameDataService gameDataService,
         TombRaiderEngineDetector engineDetector,
         ILogger<LaunchOptionsService> logger,
-        LaunchOptionsMapper mapper)
+        LaunchOptionsMapper mapper,
+        IPlatformSpecificFeatures platformSpecificFeatures)
     {
         ViewContext = viewContext;
         _gameDataService = gameDataService;
         _engineDetector = engineDetector;
         _logger = logger;
         _mapper = mapper;
+        _platformSpecificFeatures = platformSpecificFeatures;
     }
 
     public ViewServiceContext ViewContext { get; }
@@ -35,12 +40,22 @@ public class LaunchOptionsService : IViewService
     private readonly TombRaiderEngineDetector _engineDetector;
     private readonly ILogger<LaunchOptionsService> _logger;
     private readonly LaunchOptionsMapper _mapper;
+    private readonly IPlatformSpecificFeatures _platformSpecificFeatures;
     public NavigationManager NavigationManager => ViewContext.NavigationManager;
 
-    public Task LoadAsync(LaunchOptionsViewModel vm, GameMetadataViewModel game)
+    public async Task LoadAsync(LaunchOptionsViewModel vm, GameMetadataViewModel game)
     {
-        vm.InitFromGame(game);
-        return Task.CompletedTask;
+        try
+        {
+            vm.InitFromGame(game);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogError(ex, "Error reading install directory for game {GameId}", game.Id);
+            await ViewContext.PopupService.ShowLocalized("ERROR", "LAUNCH_OPTIONS_EXECUTABLE_READ_ERROR",
+                MsgBoxButton.Ok, MsgBoxImage.Error);
+            await GoBackAsync();
+        }
     }
 
     public void AutoDetect(LaunchOptionsViewModel vm)
@@ -103,7 +118,7 @@ public class LaunchOptionsService : IViewService
         var installDirectory = game.InstallDirectory ?? "";
         if (installDirectory.IsNullOrWhiteSpace())
             return [];
-        return Directory.GetFiles(installDirectory, "*.exe", SearchOption.AllDirectories)
+        return Directory.GetFiles(installDirectory, "*.exe", _platformSpecificFeatures.GetEnumerationOptions())
             .Select(p => Path.GetRelativePath(installDirectory, p))
             .ToObservableCollection();
     }

--- a/tests/TombLauncher.Tests/LaunchOptionsMapperTests.cs
+++ b/tests/TombLauncher.Tests/LaunchOptionsMapperTests.cs
@@ -3,7 +3,6 @@ using TombLauncher.Contracts.Enums;
 using TombLauncher.Core.Dtos;
 using TombLauncher.Core.PlatformSpecific;
 using TombLauncher.Mappers;
-using TombLauncher.Services;
 using TombLauncher.ViewModels.Pages;
 
 namespace TombLauncher.Tests;


### PR DESCRIPTION
Use GetEnumerationOptions() (case-insensitive, skips reparse points) instead of SearchOption.AllDirectories when scanning the install directory, fixing controls not populated on page open. Catch IOException in LoadAsync and show a localized error messagebox before navigating back. Remove orphan GetGameLaunchStartInfo from LinuxPlatformSpecificFeatures.