### PR TITLE
feat(ai): integrate support matrix into SK as a plugin

### DIFF
--- a/src/TombLauncher.Ai/Models/TroubleshootingContext.cs
+++ b/src/TombLauncher.Ai/Models/TroubleshootingContext.cs
@@ -4,6 +4,7 @@ namespace TombLauncher.Ai.Models;
 
 public class TroubleshootingContext
 {
+    public bool IsSet => GameId != 0;
     public GameEngine GameEngine { get; set; }
     public int? LastExitCode { get; set; }
     public string? LastCrashLog { get; set; }

--- a/src/TombLauncher.Ai/Plugins/GameDiagnosticsPlugin.cs
+++ b/src/TombLauncher.Ai/Plugins/GameDiagnosticsPlugin.cs
@@ -9,12 +9,12 @@ namespace TombLauncher.Ai.Plugins;
 
 public class GameDiagnosticsPlugin
 {
-    public GameDiagnosticsPlugin(TroubleshootingContext? troubleshootingContext = null)
+    public GameDiagnosticsPlugin(TroubleshootingContext troubleshootingContext)
     {
         TroubleshootingContext = troubleshootingContext;
     }
 
-    public TroubleshootingContext? TroubleshootingContext { get; }
+    public TroubleshootingContext TroubleshootingContext { get; }
     private const string NoTroubleshootingContextMessage = "No troubleshooting context in this session.";
     
     [KernelFunction]
@@ -26,18 +26,18 @@ public class GameDiagnosticsPlugin
     public string GetCurrentPlatform()
     {
         if (OperatingSystem.IsWindows())
-            return Platform.Windows.ToString();
+            return nameof(Platform.Windows);
         if (OperatingSystem.IsLinux())
-            return Platform.Linux.ToString();
+            return nameof(Platform.Linux);
 
-        return Platform.Unknown.ToString();
+        return nameof(Platform.Unknown);
     }
 
     [KernelFunction]
     [Description("Use this function to determine the engine of the custom Tomb Raider Level you're currently troubleshooting.")]
     public string GetGameEngine()
     {
-        if (TroubleshootingContext == null)
+        if (!TroubleshootingContext.IsSet)
         {
             return NoTroubleshootingContextMessage;
         }
@@ -49,7 +49,7 @@ public class GameDiagnosticsPlugin
     [Description("Use this function to determine the exit code for the latest play session. A non-zero exit code indicates an error, while zero indicates no error. In case of non-zero exit codes, you can use the *get_std_err*, *get_std_out*, and *get_last_crash_log* to retrieve additional crash information to help troubleshoot the problem.")]
     public string GetLastExitCode()
     {
-        if (TroubleshootingContext == null)
+        if (!TroubleshootingContext.IsSet)
         {
             return NoTroubleshootingContextMessage;
         }
@@ -66,7 +66,7 @@ public class GameDiagnosticsPlugin
     [Description("Use this function to get the standard error for the latest play session. Not all custom levels may write to standard error. If that's the case, you can use *get_std_out* and *get_last_crash_log* to search for additional information to help troubleshoot the current issue.")]
     public string GetLastStdErr()
     {
-        if (TroubleshootingContext == null)
+        if (!TroubleshootingContext.IsSet)
         {
             return NoTroubleshootingContextMessage;
         }
@@ -83,7 +83,7 @@ public class GameDiagnosticsPlugin
     [Description("Use this function to get the standard output for the latest play session. If the standard output is empty, you can use *get_last_crash_log* to retrieve data from the executable's log.")]
     public string GetLastStdOut()
     {
-        if (TroubleshootingContext == null)
+        if (!TroubleshootingContext.IsSet)
         {
             return NoTroubleshootingContextMessage;
         }
@@ -100,7 +100,7 @@ public class GameDiagnosticsPlugin
     [Description("Use this function to retrieve the last crash log.")]
     public string[] GetLastCrashLog([Description("The number of lines *from the end of the file* to retrieve. If null, retrieves the entire log content")]int? maxLines = null)
     {
-        if (TroubleshootingContext == null)
+        if (!TroubleshootingContext.IsSet)
             return [NoTroubleshootingContextMessage];
 
         if (TroubleshootingContext.LastCrashLog.IsNullOrWhiteSpace())

--- a/src/TombLauncher.Ai/Plugins/SupportMatrixPlugin.cs
+++ b/src/TombLauncher.Ai/Plugins/SupportMatrixPlugin.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using TombLauncher.Ai.Models;
+using TombLauncher.Contracts.Enums;
+using TombLauncher.Contracts.SupportMatrix;
+
+namespace TombLauncher.Ai.Plugins;
+
+public class SupportMatrixPlugin
+{
+    public SupportMatrixPlugin(ISupportMatrix supportMatrix,
+        TroubleshootingContext troubleshootingContext)
+    {
+        TroubleshootingContext = troubleshootingContext;
+        _supportMatrix = supportMatrix;
+    }
+
+    public TroubleshootingContext TroubleshootingContext { get; }
+    private readonly ISupportMatrix _supportMatrix;
+
+    [KernelFunction]
+    [Description("Use this function to determine if and how the game engine of the level being troubleshot is supported on the current operating system.")]
+    public string IsEngineSupported()
+    {
+        if (!TroubleshootingContext.IsSet)
+            return "Can't give an answer: current chat has no game information.";
+        var isSupported = _supportMatrix.GetEngineSupportState(TroubleshootingContext.GameEngine);
+        return isSupported switch
+        {
+            EngineSupportState.FullSupport => "This level can run natively on the current platform",
+            EngineSupportState.NativePatchingAvailable =>
+                "This level can run via compatibility layer, but can be patched to run natively",
+            EngineSupportState.SupportedWithCompatibilityLayer =>
+                "This level can run via compatibility layer, such as Wine or Proton",
+            _ => "This level is not supported in the current operating system."
+        };
+    }
+}

--- a/src/TombLauncher.Ai/Services/RagService.cs
+++ b/src/TombLauncher.Ai/Services/RagService.cs
@@ -8,6 +8,7 @@ using TombLauncher.Ai.Abstractions;
 using TombLauncher.Ai.Models;
 using TombLauncher.Ai.Plugins;
 using TombLauncher.Core.Dtos;
+using TombLauncher.Core.PlatformSpecific;
 
 namespace TombLauncher.Ai.Services;
 
@@ -18,27 +19,31 @@ public class RagService : ITroubleshootingService
     private readonly IChatCompletionService _chatCompletionService;
     private readonly PromptExecutionSettings _promptExecutionSettings;
     private readonly ILogger<RagService> _logger;
+    private readonly IPlatformSpecificFeatures _platformSpecificFeatures;
     private bool _disposed;
 
     public RagService(Kernel kernel,
         VectorSearchService vectorSearchService,
         IChatCompletionService chatCompletionService,
         PromptExecutionSettings promptExecutionSettings,
-        ILogger<RagService> logger)
+        ILogger<RagService> logger, 
+        IPlatformSpecificFeatures platformSpecificFeatures)
     {
         _kernel = kernel;
         _vectorSearchService = vectorSearchService;
         _chatCompletionService = chatCompletionService;
         _promptExecutionSettings = promptExecutionSettings;
         _logger = logger;
+        _platformSpecificFeatures = platformSpecificFeatures;
     }
 
-    public async IAsyncEnumerable<(MessageType, string)> AskAsync(string query, TroubleshootingContext? troubleshootingContext,
+    public async IAsyncEnumerable<(MessageType, string)> AskAsync(string query, TroubleshootingContext troubleshootingContext,
         ChatHistory chatHistory,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var kernel = _kernel.Clone();
         kernel.Plugins.AddFromObject(new GameDiagnosticsPlugin(troubleshootingContext));
+        kernel.Plugins.AddFromObject(new SupportMatrixPlugin(_platformSpecificFeatures.SupportMatrix, troubleshootingContext));
         var knowledgeBaseItems = await _vectorSearchService.SearchAsync(query, cancellationToken: cancellationToken);
 
         var documentationSection = string.Join("\n---\n", knowledgeBaseItems.Select(WriteDocumentation));

--- a/src/TombLauncher.Ai/Services/RagServiceLoader.cs
+++ b/src/TombLauncher.Ai/Services/RagServiceLoader.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using TombLauncher.Ai.Abstractions;
-using TombLauncher.Ai.Plugins;
+using TombLauncher.Core.PlatformSpecific;
 
 namespace TombLauncher.Ai.Services;
 
@@ -12,18 +12,21 @@ public class RagServiceLoader : ITroubleshootingServiceLoader
     private readonly Kernel _kernel;
     private readonly PromptExecutionSettings _promptExecutionSettings;
     private readonly ILogger<RagService> _ragServiceLogger;
+    private readonly IPlatformSpecificFeatures _platformSpecificFeatures;
 
     public RagServiceLoader(IChatCompletionServiceLoader chatCompletionServiceLoader,
         VectorSearchService vectorSearchService,
         Kernel kernel,
         PromptExecutionSettings promptExecutionSettings,
-        ILogger<RagService> ragServiceLogger)
+        ILogger<RagService> ragServiceLogger, 
+        IPlatformSpecificFeatures platformSpecificFeatures)
     {
         _chatCompletionServiceLoader = chatCompletionServiceLoader;
         _vectorSearchService = vectorSearchService;
         _kernel = kernel;
         _promptExecutionSettings = promptExecutionSettings;
         _ragServiceLogger = ragServiceLogger;
+        _platformSpecificFeatures = platformSpecificFeatures;
     }
 
     public async Task<ITroubleshootingService> Load(IProgress<float> progress, CancellationToken cancellationToken)
@@ -31,6 +34,6 @@ public class RagServiceLoader : ITroubleshootingServiceLoader
         var chatCompletionService =
             await _chatCompletionServiceLoader.LoadChatCompletionService(progress, cancellationToken);
 
-        return new RagService(_kernel, _vectorSearchService, chatCompletionService, _promptExecutionSettings, _ragServiceLogger);
+        return new RagService(_kernel, _vectorSearchService, chatCompletionService, _promptExecutionSettings, _ragServiceLogger, _platformSpecificFeatures);
     }
 }


### PR DESCRIPTION
Add SupportMatrixPlugin exposing ISupportMatrix to the Semantic Kernel so the AI can report engine support state during troubleshooting. Adopt null-object pattern on TroubleshootingContext (IsSet sentinel) to remove nullable parameters from plugin constructors and AskAsync.