### PR TITLE
fix(ai): correct remote KB manifest URL

### DIFF
--- a/src/TombLauncher.Ai/Services/KbUpdateService.cs
+++ b/src/TombLauncher.Ai/Services/KbUpdateService.cs
@@ -9,7 +9,7 @@ namespace TombLauncher.Ai.Services;
 
 public class KbUpdateService
 {
-    private const string RemoteManifestUrl = "https://tomblauncher.app/kb/manifest.json";
+    private const string RemoteManifestUrl = "https://tomblauncher.app/kb/kb_manifest.json";
     private const string RemoteDbUrl = "https://tomblauncher.app/kb/kb_embeddings.db";
 
     private readonly IHttpClientFactory _httpClientFactory;


### PR DESCRIPTION
The manifest file is at kb_manifest.json, not manifest.json.

This closes #127 .