### PR TITLE
fix(kb-embedder): delete existing remote file before rename to avoid …

### DIFF
--- a/src/TombLauncher.KnowledgeBase.Embedder/Services/KbUploadService.cs
+++ b/src/TombLauncher.KnowledgeBase.Embedder/Services/KbUploadService.cs
@@ -57,6 +57,8 @@ public class KbUploadService
         }
 
         _logger.LogInformation("Renaming {Tmp} → {Final}", remoteTmp, remoteFinal);
+        if (client.Exists(remoteFinal))
+            client.DeleteFile(remoteFinal);
         client.RenameFile(remoteTmp, remoteFinal);
 
         _logger.LogInformation("Uploading manifest to {Remote}", remoteManifest);


### PR DESCRIPTION
…SFTP failure

SSH_FXP_RENAME (SFTP v3) does not overwrite existing destinations, causing an SshException on second and subsequent uploads. Delete the final path first if it exists, then rename from the temp file.