### PR TITLE
feat(logging): add log rotation and separate AI log file

### DIFF
--- a/src/TombLauncher.Core/Extensions/LoggingServiceCollectionExtensions.cs
+++ b/src/TombLauncher.Core/Extensions/LoggingServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
+using Serilog.Filters;
 
 namespace TombLauncher.Core.Extensions;
 
@@ -9,19 +10,26 @@ public static class LoggingServiceCollectionExtensions
 {
     public static IServiceCollection AddTombLauncherLogging(this IServiceCollection services, string appDataDirectory)
     {
-        var logPath = Path.Combine(appDataDirectory, "TombLauncher_App.log");
+        var logPath = Path.Combine(appDataDirectory, "Logs", "TombLauncher_App.log");
+        var aiLogPath = Path.Combine(appDataDirectory, "Logs", "TombLauncher_Ai.log");
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Information()
-            .WriteTo
-            .File(logPath, LogEventLevel.Information)
+            .WriteTo.Logger(lc => lc
+                .Filter.ByExcluding(Matching.FromSource("TombLauncher.Ai"))
+                .WriteTo.File(logPath, LogEventLevel.Information, rollingInterval: RollingInterval.Day,
+                    retainedFileCountLimit: 7, fileSizeLimitBytes: 10 * 1024 * 1024, rollOnFileSizeLimit: true))
+            .WriteTo.Logger(lc => lc
+                .Filter.ByIncludingOnly(Matching.FromSource("TombLauncher.Ai"))
+                .WriteTo.File(aiLogPath, LogEventLevel.Information, rollingInterval: RollingInterval.Day,
+                    retainedFileCountLimit: 7, fileSizeLimitBytes: 10 * 1024 * 1024, rollOnFileSizeLimit: true))
             .CreateLogger();
-        AddLogging(services);
-        return services;
+
+        return services.AddLogging();
     }
 
-    private static void AddLogging(IServiceCollection services)
+    private static IServiceCollection AddLogging(this IServiceCollection services)
     {
-        services.AddLogging(opts =>
+        return services.AddLogging(opts =>
         {
             opts.ClearProviders();
             opts.SetMinimumLevel(LogLevel.Information);


### PR DESCRIPTION
Route TombLauncher.Ai logs to a dedicated file (TombLauncher_Ai.log), keeping the main app log clean. Both sinks use daily rotation with a 7-file retention limit and 10 MB size cap. Log files are now stored under a Logs/ subdirectory in the app-data folder.

This closes #135 