### PR TITLE
feat(settings): add logging settings section with open-logs-folder button

### DIFF
--- a/src/TombLauncher.Core/Extensions/LoggingServiceCollectionExtensions.cs
+++ b/src/TombLauncher.Core/Extensions/LoggingServiceCollectionExtensions.cs
@@ -10,8 +10,8 @@ public static class LoggingServiceCollectionExtensions
 {
     public static IServiceCollection AddTombLauncherLogging(this IServiceCollection services, string appDataDirectory)
     {
-        var logPath = Path.Combine(appDataDirectory, "Logs", "TombLauncher_App.log");
-        var aiLogPath = Path.Combine(appDataDirectory, "Logs", "TombLauncher_Ai.log");
+        var logPath = Path.Combine(appDataDirectory, "Logs", "TombLauncher_App_.log");
+        var aiLogPath = Path.Combine(appDataDirectory, "Logs", "TombLauncher_Ai_.log");
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Information()
             .WriteTo.Logger(lc => lc

--- a/src/TombLauncher.Core/PlatformSpecific/IPlatformSpecificFeatures.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/IPlatformSpecificFeatures.cs
@@ -7,7 +7,7 @@ namespace TombLauncher.Core.PlatformSpecific;
 public interface IPlatformSpecificFeatures
 {
     Platform Platform { get; }
-    void OpenGameFolder(string gameFolder);
+    void OpenFolder(string folder);
     void OpenUrl(string link);
     EnumerationOptions GetEnumerationOptions();
 

--- a/src/TombLauncher.Core/PlatformSpecific/LinuxPlatformSpecificFeatures.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/LinuxPlatformSpecificFeatures.cs
@@ -11,9 +11,9 @@ public class LinuxPlatformSpecificFeatures : IPlatformSpecificFeatures
 {
     public Platform Platform => Platform.Linux;
 
-    public void OpenGameFolder(string gameFolder)
+    public void OpenFolder(string folder)
     {
-        Process.Start("xdg-open", gameFolder);
+        Process.Start("xdg-open", folder);
     }
 
     public void OpenUrl(string link)

--- a/src/TombLauncher.Core/PlatformSpecific/WindowsPlatformSpecificFeatures.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/WindowsPlatformSpecificFeatures.cs
@@ -11,9 +11,9 @@ public class WindowsPlatformSpecificFeatures : IPlatformSpecificFeatures
 {
     public Platform Platform => Platform.Windows;
 
-    public void OpenGameFolder(string gameFolder)
+    public void OpenFolder(string folder)
     {
-        Process.Start("explorer", gameFolder);
+        Process.Start("explorer", folder);
     }
 
     public void OpenUrl(string link)

--- a/src/TombLauncher.Localization/Localization/cs-CZ.axaml
+++ b/src/TombLauncher.Localization/Localization/cs-CZ.axaml
@@ -528,5 +528,7 @@
     <system:String x:Key="ABOUT_INFO">Informace o aplikaci</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Zálohování uložených her...</system:String>
     <system:String x:Key="LICENSE">Licence</system:String>
+    <system:String x:Key="LOGGING">Protokolování</system:String>
+    <system:String x:Key="OPEN_LOGS_FOLDER">Otevřít složku protokolů</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/de-DE.axaml
+++ b/src/TombLauncher.Localization/Localization/de-DE.axaml
@@ -528,5 +528,7 @@
     <system:String x:Key="ABOUT_INFO">Anwendungsinformationen</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Spielstände werden gesichert...</system:String>
     <system:String x:Key="LICENSE">Lizenz</system:String>
+    <system:String x:Key="LOGGING">Protokollierung</system:String>
+    <system:String x:Key="OPEN_LOGS_FOLDER">Log-Ordner öffnen</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -536,5 +536,7 @@
     <system:String x:Key="ABOUT_INFO">Application info</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Backing up savegames...</system:String>
     <system:String x:Key="LICENSE">License</system:String>
+    <system:String x:Key="LOGGING">Logging</system:String>
+    <system:String x:Key="OPEN_LOGS_FOLDER">Open logs folder</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/es-ES.axaml
+++ b/src/TombLauncher.Localization/Localization/es-ES.axaml
@@ -528,5 +528,7 @@
     <system:String x:Key="ABOUT_INFO">Información de la aplicación</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Haciendo copia de seguridad de las partidas guardadas...</system:String>
     <system:String x:Key="LICENSE">Licencia</system:String>
+    <system:String x:Key="LOGGING">Registro</system:String>
+    <system:String x:Key="OPEN_LOGS_FOLDER">Abrir carpeta de registros</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/fr-FR.axaml
+++ b/src/TombLauncher.Localization/Localization/fr-FR.axaml
@@ -528,5 +528,7 @@
     <system:String x:Key="ABOUT_INFO">Informations sur l'application</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Sauvegarde des parties en cours...</system:String>
     <system:String x:Key="LICENSE">Licence</system:String>
+    <system:String x:Key="LOGGING">Journalisation</system:String>
+    <system:String x:Key="OPEN_LOGS_FOLDER">Ouvrir le dossier des journaux</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -535,5 +535,7 @@
     <system:String x:Key="GATHERING_STATISTICS">Raccolta statistiche...</system:String>
     <system:String x:Key="RELOAD">Ricarica</system:String>
     <system:String x:Key="FOLDER_NAMES_CANNOT_END_WITH_A_DOR_OR_A_SPACE">I nomi delle cartelle non possono terminare con un punto o uno spazio</system:String>
+    <system:String x:Key="LOGGING">Log</system:String>
+    <system:String x:Key="OPEN_LOGS_FOLDER">Apri cartella log</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/pl-PL.axaml
+++ b/src/TombLauncher.Localization/Localization/pl-PL.axaml
@@ -528,5 +528,7 @@
     <system:String x:Key="ABOUT_INFO">Informacje o aplikacji</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Tworzenie kopii zapasowych zapisów...</system:String>
     <system:String x:Key="LICENSE">Licencja</system:String>
+    <system:String x:Key="LOGGING">Rejestrowanie</system:String>
+    <system:String x:Key="OPEN_LOGS_FOLDER">Otwórz folder dzienników</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher/Services/GameDetailsService.cs
+++ b/src/TombLauncher/Services/GameDetailsService.cs
@@ -64,7 +64,7 @@ public class GameDetailsService : IViewService
 
     public void OpenGameFolder(string gameFolder)
     {
-        _platformSpecificFeatures.OpenGameFolder(gameFolder);
+        _platformSpecificFeatures.OpenFolder(gameFolder);
     }
 
     public async Task FetchLinks(GameDetailsViewModel game, LinkType linkType)

--- a/src/TombLauncher/ViewModels/Pages/Settings/LoggingSettingsViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/Settings/LoggingSettingsViewModel.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using CommunityToolkit.Mvvm.Input;
+using IconPacks.Avalonia.RemixIcon;
+using TombLauncher.Core.PlatformSpecific;
+
+namespace TombLauncher.ViewModels.Pages.Settings;
+
+public partial class LoggingSettingsViewModel : SettingsSectionViewModelBase
+{
+    public LoggingSettingsViewModel(IPlatformSpecificFeatures platformSpecificFeatures, PageViewModel settingsPage) :
+        base("LOGGING", settingsPage, PackIconRemixIconKind.FilePaper2Line)
+    {
+        _logsFolder = Path.Combine(platformSpecificFeatures.GetAppDataDirectory(), "Logs");
+        _platformSpecificFeatures = platformSpecificFeatures;
+    }
+
+    private readonly string _logsFolder;
+    private readonly IPlatformSpecificFeatures _platformSpecificFeatures;
+
+    [RelayCommand]
+    private void OpenLogsFolder()
+    {
+        _platformSpecificFeatures.OpenFolder(_logsFolder);
+    }
+}

--- a/src/TombLauncher/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/SettingsPageViewModel.cs
@@ -166,6 +166,8 @@ public partial class SettingsPageViewModel : PageViewModel, IChangeTracking
                     compatVm.AvailableProtonInstallations.FirstOrDefault(p => p.ExecutablePath == compat.ProtonPath);
             }
 
+            var loggingSettings = new LoggingSettingsViewModel(_platformSpecificFeatures, this);
+
             Sections.Add(welcomePageSettings);
             Sections.Add(appearanceSettings);
             Sections.Add(languageSettings);
@@ -173,8 +175,8 @@ public partial class SettingsPageViewModel : PageViewModel, IChangeTracking
             Sections.Add(gameDetailsSettings);
             Sections.Add(savegameSettings);
             Sections.Add(aiSettings);
-
             Sections.Add(compatVm);
+            Sections.Add(loggingSettings);
 
             AcceptChanges();
         });

--- a/src/TombLauncher/Views/LoggingSettingsView.axaml
+++ b/src/TombLauncher/Views/LoggingSettingsView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:TombLauncher.Controls;assembly=TombLauncher.Controls"
+             xmlns:localization="clr-namespace:TombLauncher.Localization;assembly=TombLauncher.Localization"
+             xmlns:settings="clr-namespace:TombLauncher.ViewModels.Pages.Settings"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="TombLauncher.Views.LoggingSettingsView"
+             x:DataType="settings:LoggingSettingsViewModel">
+    <controls:IconButton Icon="ExternalLinkLine" 
+                         Classes="btn-primary"
+                         Height="45"
+                         Text="{localization:Translate OPEN_LOGS_FOLDER}" 
+                         Command="{Binding OpenLogsFolderCommand}"/>
+</UserControl>

--- a/src/TombLauncher/Views/LoggingSettingsView.axaml.cs
+++ b/src/TombLauncher/Views/LoggingSettingsView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace TombLauncher.Views;
+
+public partial class LoggingSettingsView : UserControl
+{
+    public LoggingSettingsView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Implements LoggingSettingsViewModel and its view with a button to open the logs folder in the system file manager. Generalizes OpenGameFolder to OpenFolder on IPlatformSpecificFeatures to make it reusable. Adds LOGGING and OPEN_LOGS_FOLDER localization keys to all 7 languages.

Closes #136 