### PR TITLE
feat(ui): style GamesDataGridView and add author/thumbnail columns (#141)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin\\Debug/
 *.log
 TombLauncher_App.log
 TombLauncher.db
+.claude/settings.json

--- a/src/TombLauncher.Localization/Localization/cs-CZ.axaml
+++ b/src/TombLauncher.Localization/Localization/cs-CZ.axaml
@@ -27,6 +27,7 @@
     <system:String x:Key="NO_GAMES">Žádné hry</system:String>
     <system:String x:Key="TRY_ADDING_ONE">Zkuste přidat jednu</system:String>
     <system:String x:Key="TITLE">Název</system:String>
+    <system:String x:Key="TITLE_PICTURE">Obal</system:String>
     <system:String x:Key="RELEASE_DATE">Datum vydání</system:String>
     <system:String x:Key="INSTALL_DATE">Datum instalace</system:String>
     <system:String x:Key="ENGINE">Engine</system:String>

--- a/src/TombLauncher.Localization/Localization/de-DE.axaml
+++ b/src/TombLauncher.Localization/Localization/de-DE.axaml
@@ -27,6 +27,7 @@
     <system:String x:Key="NO_GAMES">Keine Spiele</system:String>
     <system:String x:Key="TRY_ADDING_ONE">Versuche, eines hinzuzufügen</system:String>
     <system:String x:Key="TITLE">Titel</system:String>
+    <system:String x:Key="TITLE_PICTURE">Coverbild</system:String>
     <system:String x:Key="RELEASE_DATE">Erscheinungsdatum</system:String>
     <system:String x:Key="INSTALL_DATE">Installationsdatum</system:String>
     <system:String x:Key="ENGINE">Engine</system:String>

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -28,6 +28,7 @@
     <system:String x:Key="NO_GAMES">No games</system:String>
     <system:String x:Key="TRY_ADDING_ONE">Try adding one</system:String>
     <system:String x:Key="TITLE">Title</system:String>
+    <system:String x:Key="TITLE_PICTURE">Cover</system:String>
     <system:String x:Key="RELEASE_DATE">Release date</system:String>
     <system:String x:Key="INSTALL_DATE">Install date</system:String>
     <system:String x:Key="ENGINE">Engine</system:String>

--- a/src/TombLauncher.Localization/Localization/es-ES.axaml
+++ b/src/TombLauncher.Localization/Localization/es-ES.axaml
@@ -27,6 +27,7 @@
     <system:String x:Key="NO_GAMES">Sin juegos</system:String>
     <system:String x:Key="TRY_ADDING_ONE">Intenta añadir uno</system:String>
     <system:String x:Key="TITLE">Título</system:String>
+    <system:String x:Key="TITLE_PICTURE">Portada</system:String>
     <system:String x:Key="RELEASE_DATE">Fecha de lanzamiento</system:String>
     <system:String x:Key="INSTALL_DATE">Fecha de instalación</system:String>
     <system:String x:Key="ENGINE">Motor</system:String>

--- a/src/TombLauncher.Localization/Localization/fr-FR.axaml
+++ b/src/TombLauncher.Localization/Localization/fr-FR.axaml
@@ -27,6 +27,7 @@
     <system:String x:Key="NO_GAMES">Aucun jeu</system:String>
     <system:String x:Key="TRY_ADDING_ONE">Essayez d'en ajouter un</system:String>
     <system:String x:Key="TITLE">Titre</system:String>
+    <system:String x:Key="TITLE_PICTURE">Couverture</system:String>
     <system:String x:Key="RELEASE_DATE">Date de sortie</system:String>
     <system:String x:Key="INSTALL_DATE">Date d'installation</system:String>
     <system:String x:Key="ENGINE">Moteur</system:String>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -27,6 +27,7 @@
     <system:String x:Key="NO_GAMES">Nessun gioco</system:String>
     <system:String x:Key="TRY_ADDING_ONE">Prova ad aggiungerne uno</system:String>
     <system:String x:Key="TITLE">Titolo</system:String>
+    <system:String x:Key="TITLE_PICTURE">Copertina</system:String>
     <system:String x:Key="RELEASE_DATE">Data di uscita</system:String>
     <system:String x:Key="INSTALL_DATE">Data di installazione</system:String>
     <system:String x:Key="ENGINE">Motore</system:String>

--- a/src/TombLauncher.Localization/Localization/pl-PL.axaml
+++ b/src/TombLauncher.Localization/Localization/pl-PL.axaml
@@ -27,6 +27,7 @@
     <system:String x:Key="NO_GAMES">Brak gier</system:String>
     <system:String x:Key="TRY_ADDING_ONE">Spróbuj dodać jedną</system:String>
     <system:String x:Key="TITLE">Tytuł</system:String>
+    <system:String x:Key="TITLE_PICTURE">Okładka</system:String>
     <system:String x:Key="RELEASE_DATE">Data wydania</system:String>
     <system:String x:Key="INSTALL_DATE">Data instalacji</system:String>
     <system:String x:Key="ENGINE">Silnik</system:String>

--- a/src/TombLauncher/Assets/AppStyles.axaml
+++ b/src/TombLauncher/Assets/AppStyles.axaml
@@ -641,4 +641,41 @@
         <Setter Property="FontSize" Value="15"/>
         <Setter Property="Margin" Value="0,8,0,2"/>
     </Style>
+
+    <!-- DataGrid -->
+    <Style Selector="DataGrid">
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="RowBackground" Value="{DynamicResource CardBackgroundBrush}" />
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource CardBorderBrush}" />
+        <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource CardBorderBrush}" />
+    </Style>
+
+    <Style Selector="DataGridColumnHeader">
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Setter Property="SeparatorBrush" Value="{DynamicResource CardBorderBrush}" />
+    </Style>
+
+    <Style Selector="DataGridRow">
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}" />
+        <Setter Property="MinHeight" Value="48" />
+    </Style>
+
+    <Style Selector="DataGridRow:nth-child(even)">
+        <Setter Property="Background" Value="{DynamicResource PageBackgroundBrush}" />
+    </Style>
+
+    <Style Selector="DataGridRow:selected">
+        <Setter Property="Background" Value="{DynamicResource PrimaryBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ColoredButtonTextBrush}" />
+    </Style>
+
+    <Style Selector="DataGridRow:selected DataGridCell">
+        <Setter Property="Foreground" Value="{DynamicResource ColoredButtonTextBrush}" />
+    </Style>
+
+    <Style Selector="DataGridCell">
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+    </Style>
 </Styles>

--- a/src/TombLauncher/Assets/AppStyles.axaml
+++ b/src/TombLauncher/Assets/AppStyles.axaml
@@ -385,15 +385,19 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Cursor" Value="Hand"></Setter>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryColor}"></Setter>
     </Style>
+    
     <Style Selector=":is(ToggleButton).icon-only:checked">
         <Style Selector="^:checked /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="Transparent"></Setter>
+            <Setter Property="Foreground" Value="{DynamicResource PrimaryColor}"></Setter>
         </Style>
         <Setter Property="Background" Value="Transparent"/>
         
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Cursor" Value="Hand"></Setter>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryColor}"></Setter>
     </Style>
 
     <Style Selector="ListBox">

--- a/src/TombLauncher/Views/GamesDataGridView.axaml
+++ b/src/TombLauncher/Views/GamesDataGridView.axaml
@@ -86,7 +86,10 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="{loc:Translate TITLE_PICTURE}" Width="72">
+                <DataGridTemplateColumn Width="72">
+                    <DataGridTemplateColumn.Header>
+                        <iconPacks:PackIconRemixIcon Kind="Image2Line" ToolTip.Tip="{loc:Translate TITLE_PICTURE}" />
+                    </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Image Source="{Binding GameMetadata.TitlePic}" Height="48" Stretch="Uniform" />

--- a/src/TombLauncher/Views/GamesDataGridView.axaml
+++ b/src/TombLauncher/Views/GamesDataGridView.axaml
@@ -14,39 +14,40 @@
         <pages:GameListViewModel />
     </Design.DataContext>
     <UserControl.Resources>
-        <valueConverters:BooleanToIconConverter x:Key="AddToFavouritesBooleanToIconConverter" 
-                                                        TrueValue="HeartFill" 
+        <valueConverters:BooleanToIconConverter x:Key="AddToFavouritesBooleanToIconConverter"
+                                                        TrueValue="HeartFill"
                                                         FalseValue="HeartLine"/>
-        <valueConverters:BooleanToStringConverter x:Key="AddRemoveFromFavouritesBooleanConverter" 
-                                                  TrueValue="{loc:Translate REMOVE_FROM_FAVOURITES}" 
+        <valueConverters:BooleanToStringConverter x:Key="AddRemoveFromFavouritesBooleanConverter"
+                                                  TrueValue="{loc:Translate REMOVE_FROM_FAVOURITES}"
                                                   FalseValue="{loc:Translate ADD_TO_FAVOURITES}"/>
-        <valueConverters:BooleanToIconConverter x:Key="MarkAsCompletedBooleanToIconConverter" 
-                                                        TrueValue="TrophyFill" 
+        <valueConverters:BooleanToIconConverter x:Key="MarkAsCompletedBooleanToIconConverter"
+                                                        TrueValue="TrophyFill"
                                                         FalseValue="TrophyLine"/>
-        <valueConverters:BooleanToStringConverter x:Key="MarkUnmarkCompletedBooleanConverter" 
-                                                  TrueValue="{loc:Translate UNMARK_AS_COMPLETED}" 
+        <valueConverters:BooleanToStringConverter x:Key="MarkUnmarkCompletedBooleanConverter"
+                                                  TrueValue="{loc:Translate UNMARK_AS_COMPLETED}"
                                                   FalseValue="{loc:Translate MARK_AS_COMPLETED}"/>
     </UserControl.Resources>
-    <DataGrid ItemsSource="{Binding Games}" 
-              IsReadOnly="True" 
+    <DataGrid ItemsSource="{Binding Games}"
+              IsReadOnly="True"
               x:Name="GamesDataGrid"
-              IsVisible="{Binding Games, Converter={StaticResource CollectionNotEmptyToVisibilityConverter}}" 
+              IsVisible="{Binding Games, Converter={StaticResource CollectionNotEmptyToVisibilityConverter}}"
               SelectedItem="{Binding SelectedGame}"
+              RowHeight="48"
               FrozenColumnCount="1">
             <DataGrid.ContextMenu>
                 <ContextMenu>
-                    <MenuItem Header="{loc:Translate Play}" 
+                    <MenuItem Header="{loc:Translate PLAY}"
                               Command="{Binding PlayCommand}"
                               CommandParameter="{Binding SelectedGame}">
                         <MenuItem.Icon>
                             <iconPacks:PackIconRemixIcon Kind="PlayLargeFill"/>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="{loc:Translate VIEW_DETAILS}" 
-                              Command="{Binding OpenCommand}" 
+                    <MenuItem Header="{loc:Translate VIEW_DETAILS}"
+                              Command="{Binding OpenCommand}"
                               CommandParameter="{Binding SelectedGame}"/>
                     <Separator/>
-                    <MenuItem Header="{Binding SelectedGame.GameMetadata.IsFavourite, Converter={StaticResource AddRemoveFromFavouritesBooleanConverter}}" 
+                    <MenuItem Header="{Binding SelectedGame.GameMetadata.IsFavourite, Converter={StaticResource AddRemoveFromFavouritesBooleanConverter}}"
                               Command="{Binding AddToFavouritesCommand}"
                               CommandParameter="{Binding SelectedGame}">
                         <MenuItem.Icon>
@@ -61,8 +62,8 @@
                         </MenuItem.Icon>
                     </MenuItem>
                     <Separator/>
-                    <MenuItem Header="{loc:Translate UNINSTALL}" 
-                              Command="{Binding UninstallCommand}" 
+                    <MenuItem Header="{loc:Translate UNINSTALL}"
+                              Command="{Binding UninstallCommand}"
                               CommandParameter="{Binding SelectedGame}">
                         <MenuItem.Icon>
                             <iconPacks:PackIconRemixIcon Kind="DeleteBinLine" Foreground="{DynamicResource DangerBrush}"/>
@@ -85,16 +86,24 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="{loc:Translate TITLE_PICTURE}" Width="72">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Image Source="{Binding GameMetadata.TitlePic}" Height="48" Stretch="Uniform" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
                 <DataGridTextColumn Header="{loc:Translate TITLE}" Binding="{Binding GameMetadata.Title}" />
+                <DataGridTextColumn Header="{loc:Translate AUTHOR}" Binding="{Binding GameMetadata.Author}" />
                 <DataGridTemplateColumn >
                     <DataGridTemplateColumn.Header>
-                        <iconPacks:PackIconRemixIcon ToolTip.Tip="{loc:Translate FAVOURITE}" 
+                        <iconPacks:PackIconRemixIcon ToolTip.Tip="{loc:Translate FAVOURITE}"
                                                Kind="HeartLine"/>
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ToggleButton Classes="icon-only" 
-                                          Command="{Binding ToggleFavouriteCommand}" 
+                            <ToggleButton Classes="icon-only"
+                                          Command="{Binding ToggleFavouriteCommand}"
                                           ToolTip.Tip="{Binding GameMetadata.IsFavourite, Converter={StaticResource AddRemoveFromFavouritesBooleanConverter}}">
                                 <iconPacks:PackIconRemixIcon Kind="{Binding GameMetadata.IsFavourite, Converter={StaticResource AddToFavouritesBooleanToIconConverter}}"/>
                             </ToggleButton>
@@ -103,13 +112,13 @@
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn >
                     <DataGridTemplateColumn.Header>
-                        <iconPacks:PackIconRemixIcon ToolTip.Tip="{loc:Translate COMPLETED}" 
+                        <iconPacks:PackIconRemixIcon ToolTip.Tip="{loc:Translate COMPLETED}"
                                                Kind="TrophyLine"/>
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ToggleButton Classes="icon-only" 
-                                          Command="{Binding ToggleCompletedCommand}" 
+                            <ToggleButton Classes="icon-only"
+                                          Command="{Binding ToggleCompletedCommand}"
                                           ToolTip.Tip="{Binding GameMetadata.IsCompleted, Converter={StaticResource MarkUnmarkCompletedBooleanConverter}}">
                                 <iconPacks:PackIconRemixIcon Kind="{Binding GameMetadata.IsCompleted, Converter={StaticResource MarkAsCompletedBooleanToIconConverter}}"/>
                             </ToggleButton>


### PR DESCRIPTION
- Add DataGrid styles to AppStyles.axaml using existing semantic brushes:
  card background/border, primary, text, and page background for
  even-row alternation
- Add thumbnail (TitlePic) and Author columns; fix row height stability
  on horizontal scroll via RowHeight="48" and fixed column Width="72"
- Use icon header (Image2Line + tooltip) for the cover column,
  consistent with Favourite and Completed columns
- Fix inconsistent foreground on icon-only ToggleButtons by overriding
  Fluent theme state management with PrimaryColor
- Add TITLE_PICTURE localization key to all 7 language files
- Fix context menu key casing: Play → PLAY

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Closes #141 
