### PR TITLE
fix(ui): improve GameDetailsView hero image rendering

### DIFF
--- a/src/TombLauncher/Assets/Themes/HorusLight.axaml
+++ b/src/TombLauncher/Assets/Themes/HorusLight.axaml
@@ -5,7 +5,9 @@
     <Color x:Key="CardBackgroundColor">#CCE8F0FA</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" /> <!-- Glassy Light Azure -->
     <SolidColorBrush x:Key="CardBorderBrush">#33000000</SolidColorBrush>
-    <SolidColorBrush x:Key="PageBackgroundBrush">#FAFCFF</SolidColorBrush>
+    <Color x:Key="PageBackgroundColor">#FAFCFF</Color>
+    <Color x:Key="PageBackgroundColorTransparent">#00FAFCFF</Color>
+    <SolidColorBrush x:Key="PageBackgroundBrush" Color="{StaticResource PageBackgroundColor}"/>
     <SolidColorBrush x:Key="SidebarBackgroundBrush">#F0F5FC</SolidColorBrush>
     
     <!-- Primary Actions -->

--- a/src/TombLauncher/Assets/Themes/HorusTheme.axaml
+++ b/src/TombLauncher/Assets/Themes/HorusTheme.axaml
@@ -5,7 +5,9 @@
     <Color x:Key="CardBackgroundColor">#CC0F1A2E</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" /> <!-- Deep Midnight Blue -->
     <SolidColorBrush x:Key="CardBorderBrush">#33FFFFFF</SolidColorBrush>
-    <SolidColorBrush x:Key="PageBackgroundBrush">#0A1020</SolidColorBrush>
+    <Color x:Key="PageBackgroundColor">#0A1020</Color>
+    <Color x:Key="PageBackgroundColorTransparent">#000A1020</Color>
+    <SolidColorBrush x:Key="PageBackgroundBrush" Color="{StaticResource PageBackgroundColor}"/>
     <SolidColorBrush x:Key="SidebarBackgroundBrush">#060C18</SolidColorBrush>
 
     <!-- Fluent Theme Overrides -->

--- a/src/TombLauncher/Assets/Themes/ScionLight.axaml
+++ b/src/TombLauncher/Assets/Themes/ScionLight.axaml
@@ -5,7 +5,9 @@
     <Color x:Key="CardBackgroundColor">#CCF0F8F8</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" /> <!-- Glassy Light Teal -->
     <SolidColorBrush x:Key="CardBorderBrush">#33000000</SolidColorBrush>
-    <SolidColorBrush x:Key="PageBackgroundBrush">#FFFFFF</SolidColorBrush>
+    <Color x:Key="PageBackgroundColor">#FFFFFF</Color>
+    <Color x:Key="PageBackgroundColorTransparent">#00FFFFFF</Color>
+    <SolidColorBrush x:Key="PageBackgroundBrush" Color="{StaticResource PageBackgroundColor}"/>
     <SolidColorBrush x:Key="SidebarBackgroundBrush">#F8FDFD</SolidColorBrush>
     
     <!-- Primary Actions -->

--- a/src/TombLauncher/Assets/Themes/ScionTheme.axaml
+++ b/src/TombLauncher/Assets/Themes/ScionTheme.axaml
@@ -5,7 +5,9 @@
     <Color x:Key="CardBackgroundColor">#CC1A2626</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" /> <!-- Glassy Dark Teal -->
     <SolidColorBrush x:Key="CardBorderBrush">#33FFFFFF</SolidColorBrush>
-    <SolidColorBrush x:Key="PageBackgroundBrush">#0F1515</SolidColorBrush>
+    <Color x:Key="PageBackgroundColor">#0F1515</Color>
+    <Color x:Key="PageBackgroundColorTransparent">#000F1515</Color>
+    <SolidColorBrush x:Key="PageBackgroundBrush" Color="{StaticResource PageBackgroundColor}"/>
     <!-- Fluent Theme Overrides -->
     <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="{StaticResource CardBackgroundColor}" />
     <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="{StaticResource CardBackgroundColor}" />

--- a/src/TombLauncher/Assets/Themes/XianLight.axaml
+++ b/src/TombLauncher/Assets/Themes/XianLight.axaml
@@ -5,7 +5,9 @@
     <Color x:Key="CardBackgroundColor">#CCF8F0F0</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" /> <!-- Glassy Light Rust -->
     <SolidColorBrush x:Key="CardBorderBrush">#33000000</SolidColorBrush>
-    <SolidColorBrush x:Key="PageBackgroundBrush">#FFFFFF</SolidColorBrush>
+    <Color x:Key="PageBackgroundColor">#FFFFFF</Color>
+    <Color x:Key="PageBackgroundColorTransparent">#00FFFFFF</Color>
+    <SolidColorBrush x:Key="PageBackgroundBrush" Color="{StaticResource PageBackgroundColor}"/>
     <SolidColorBrush x:Key="SidebarBackgroundBrush">#FCF5F5</SolidColorBrush>
     
     <!-- Primary Actions -->

--- a/src/TombLauncher/Assets/Themes/XianTheme.axaml
+++ b/src/TombLauncher/Assets/Themes/XianTheme.axaml
@@ -5,7 +5,9 @@
     <Color x:Key="CardBackgroundColor">#CC261A1A</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" /> <!-- Glassy Dark Rust -->
     <SolidColorBrush x:Key="CardBorderBrush">#33FFFFFF</SolidColorBrush>
-    <SolidColorBrush x:Key="PageBackgroundBrush">#150F0F</SolidColorBrush>
+    <Color x:Key="PageBackgroundColor">#150F0F</Color>
+    <Color x:Key="PageBackgroundColorTransparent">#00150F0F</Color>
+    <SolidColorBrush x:Key="PageBackgroundBrush" Color="{StaticResource PageBackgroundColor}"/>
     <SolidColorBrush x:Key="SidebarBackgroundBrush">#0F0B0B</SolidColorBrush>
 
     <!-- Fluent Theme Overrides -->

--- a/src/TombLauncher/Views/Pages/GameDetailsView.axaml
+++ b/src/TombLauncher/Views/Pages/GameDetailsView.axaml
@@ -38,16 +38,15 @@
             <ColumnDefinition Width="*"></ColumnDefinition>
         </Grid.ColumnDefinitions>
         <Grid Grid.Row="0">
-            <Image Source="{Binding Game.GameMetadata.TitlePic}" Stretch="UniformToFill" HorizontalAlignment="Left">
-                <Image.OpacityMask>
-                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%, 100%">
-                        <LinearGradientBrush.GradientStops>
-                            <GradientStop Offset="0" Color="Black"/>
-                            <GradientStop Offset="1" Color="Transparent"/>
-                        </LinearGradientBrush.GradientStops>
+            <Image Source="{Binding Game.GameMetadata.TitlePic}" Stretch="UniformToFill" HorizontalAlignment="Left" />
+            <Border>
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                        <GradientStop Offset="0.4" Color="{DynamicResource PageBackgroundColorTransparent}"/>
+                        <GradientStop Offset="1"   Color="{DynamicResource PageBackgroundColor}"/>
                     </LinearGradientBrush>
-                </Image.OpacityMask>
-            </Image>
+                </Border.Background>
+            </Border>
             <StackPanel VerticalAlignment="Bottom">
                 <TextBlock FontWeight="DemiBold"
                            FontSize="60"

--- a/src/TombLauncher/Views/Pages/GameDetailsView.axaml
+++ b/src/TombLauncher/Views/Pages/GameDetailsView.axaml
@@ -38,7 +38,7 @@
             <ColumnDefinition Width="*"></ColumnDefinition>
         </Grid.ColumnDefinitions>
         <Grid Grid.Row="0">
-            <Image Source="{Binding Game.GameMetadata.TitlePic}" Stretch="None" HorizontalAlignment="Left">
+            <Image Source="{Binding Game.GameMetadata.TitlePic}" Stretch="UniformToFill" HorizontalAlignment="Left">
                 <Image.OpacityMask>
                     <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%, 100%">
                         <LinearGradientBrush.GradientStops>


### PR DESCRIPTION
- Switch image Stretch from None to UniformToFill so the cover fills
  the hero area regardless of image dimensions
- Replace top-to-bottom OpacityMask with a Border gradient overlay:
  the image stays intact and only the bottom portion fades into the
  page background
- Add PageBackgroundColor and PageBackgroundColorTransparent (same hue,
  alpha=0) to all 6 themes to prevent the grey banding artifact caused
  by interpolating towards #00000000

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Closes #147 