### PR TITLE
fix(ui): disable Play button when game engine is unknown

### DIFF
--- a/src/TombLauncher.Ai/Extensions/EmbedderRegistrationExtensions.cs
+++ b/src/TombLauncher.Ai/Extensions/EmbedderRegistrationExtensions.cs
@@ -1,4 +1,6 @@
 using System.ClientModel;
+using System.Net.Security;
+using System.Security.Authentication;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -8,7 +10,6 @@ using TombLauncher.Ai.Abstractions;
 using TombLauncher.Ai.Configuration;
 using TombLauncher.Ai.Factories;
 using TombLauncher.Ai.Mappers;
-using TombLauncher.Ai.Plugins;
 using TombLauncher.Ai.Services;
 using TombLauncher.Ai.Services.AiBackends;
 using TombLauncher.Ai.Utils;
@@ -25,7 +26,11 @@ public static class EmbedderRegistrationExtensions
             {
                 var aiConfig = sp.GetRequiredService<IOptions<AiConfig>>().Value;
                 return new OpenAIClient(new ApiKeyCredential(aiConfig.ApiKey ?? "ollama"),
-                    new OpenAIClientOptions() { Endpoint = new Uri(OllamaEndpointHelper.NormalizeEndpoint(aiConfig.Endpoint ?? "http://localhost:11434")) });
+                    new OpenAIClientOptions()
+                    {
+                        Endpoint = new Uri(
+                            OllamaEndpointHelper.NormalizeEndpoint(aiConfig.Endpoint ?? "http://localhost:11434"))
+                    });
             })
             .AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
             {
@@ -42,7 +47,7 @@ public static class EmbedderRegistrationExtensions
 
     public static IServiceCollection RegisterAiFeatures(this IServiceCollection serviceCollection)
     {
-        return serviceCollection
+        serviceCollection
             .AddScoped<ITroubleshootingServiceLoader, RagServiceLoader>()
             .AddSingleton<VectorSearchService>()
             .AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
@@ -51,12 +56,19 @@ public static class EmbedderRegistrationExtensions
             .AddScoped<TroubleshootingContextService>()
             .AddScoped<IChatCompletionServiceLoader, OpenAiCompatibleChatCompletionServiceLoader>()
             .AddScoped<PromptExecutionSettings>(_ => new PromptExecutionSettings()
-                { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(), ExtensionData = new Dictionary<string, object> { ["temperature"] = 0.65 }})
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                ExtensionData = new Dictionary<string, object> { ["temperature"] = 0.65 }
+            })
             .AddSingleton<OpenAIClient>(sp =>
             {
                 var aiConfig = sp.GetRequiredService<IAiConfig>();
                 return new OpenAIClient(new ApiKeyCredential(aiConfig.ApiKey ?? "ollama"),
-                    new OpenAIClientOptions() { Endpoint = new Uri(OllamaEndpointHelper.NormalizeEndpoint(aiConfig.Endpoint ?? "http://localhost:11434")) });
+                    new OpenAIClientOptions()
+                    {
+                        Endpoint = new Uri(
+                            OllamaEndpointHelper.NormalizeEndpoint(aiConfig.Endpoint ?? "http://localhost:11434"))
+                    });
             })
             .AddSingleton<Kernel>(sp =>
             {
@@ -72,13 +84,22 @@ public static class EmbedderRegistrationExtensions
                 {
                     Console.WriteLine(ex);
                 }
+
                 return kernelBuilder.Build();
             })
-            .AddHttpClient()
             .AddSingleton<KbUpdateService>()
             .AddSingleton<ModelMapper>()
             .AddKeyedSingleton<IAiBackendService, OllamaBackendService>(AiBackendType.Ollama)
             .AddKeyedSingleton<IAiBackendService, LmStudioBackendService>(AiBackendType.LmStudio)
-            .AddSingleton<AiBackendFactory>();
+            .AddSingleton<AiBackendFactory>()
+            .AddHttpClient(nameof(KbUpdateService))
+            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler()
+            {
+                SslOptions = new SslClientAuthenticationOptions()
+                {
+                    EnabledSslProtocols = SslProtocols.Tls13
+                }
+            });
+        return serviceCollection;
     }
 }

--- a/src/TombLauncher.Ai/Services/KbUpdateService.cs
+++ b/src/TombLauncher.Ai/Services/KbUpdateService.cs
@@ -37,7 +37,7 @@ public class KbUpdateService
         KbManifest remoteManifest;
         try
         {
-            using var client = _httpClientFactory.CreateClient();
+            using var client = _httpClientFactory.CreateClient(nameof(KbUpdateService));
             client.Timeout = TimeSpan.FromSeconds(3);
             var json = await client.GetStringAsync(RemoteManifestUrl, ct);
             remoteManifest = JsonSerializer.Deserialize<KbManifest>(json,
@@ -72,7 +72,7 @@ public class KbUpdateService
 
         try
         {
-            using var client = _httpClientFactory.CreateClient();
+            using var client = _httpClientFactory.CreateClient(nameof(KbUpdateService));
             await using var fileStream = File.Create(tmpZipPath);
             await client.DownloadAsync(RemoteDbUrl, fileStream, cancellationToken: ct);
         }

--- a/src/TombLauncher.KnowledgeBase.Embedder/Input/04_tomb_launcher_faq/04_tomb_launcher_faq.md
+++ b/src/TombLauncher.KnowledgeBase.Embedder/Input/04_tomb_launcher_faq/04_tomb_launcher_faq.md
@@ -129,3 +129,11 @@ We'd be grateful to receive your suggestions to improve our localization support
 The language files are AXAML files located in the `Localization` folder inside Tomb Launcher's installation directory. You do not need to recompile the application to add a new language — simply create a new AXAML file in that folder containing the translated strings for your language, following the same structure as the existing `en-US.axaml` or `it-IT.axaml` files.
 
 Once you have a translation ready, open an issue on the [GitHub repository](https://github.com/ALDamico/TombLauncher/issues) to share it with the developer so it can be included in a future release.
+
+## Why does the page stay in a loading state when I click Play?
+Versions of Tomb Launcher prior to 1.4.0 did not prevent you from clicking the Play button if the application was not able to determine the game engine or its executable.  
+To fix this behaviour, set its engine manually and select the game executable in the Game Launch options page.
+
+## Why is the Play button greyed out?
+This means Tomb Launcher was not able to detect the game engine automatically. Set it explicitly in the Game Launch options page, and select its executable.  
+The Play button will become active.

--- a/src/TombLauncher.KnowledgeBase.Embedder/Input/04_tomb_launcher_faq/metadata.json
+++ b/src/TombLauncher.KnowledgeBase.Embedder/Input/04_tomb_launcher_faq/metadata.json
@@ -10,6 +10,14 @@
     {
       "header": "How do I set global compatibility defaults for Linux?",
       "platforms": ["Linux"]
+    },
+    {
+      "header": "Why does the page stays in a loading state when I click Play?",
+      "appVersionRange": "(,1.3.0]"
+    },
+    {
+      "header": "Why is the Play button greyed out?",
+      "appVersionRange": "[1.4.0,)"
     }
   ]
 }

--- a/src/TombLauncher.Localization/Localization/cs-CZ.axaml
+++ b/src/TombLauncher.Localization/Localization/cs-CZ.axaml
@@ -535,5 +535,6 @@
     <system:String x:Key="MANIFEST_FETCH_FAILURE">Nelze načíst informace o aktualizaci znalostní báze</system:String>
     <system:String x:Key="KB_DOWNLOAD_FAILURE">Chyba při stahování znalostní báze</system:String>
     <system:String x:Key="KB_ERROR_TRANSIENT_NOTICE">Obvykle se jedná o přechodné chyby, které lze bezpečně ignorovat.</system:String>
+    <system:String x:Key="AUTOMATIC_ENGINE_DETECTION_FAILED_SET_MANUALLY">Tomb Launcher nemohl automaticky rozpoznat engine tohoto levelu. Nastavte jej ručně, abyste aktivovali tlačítko Hrát.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/de-DE.axaml
+++ b/src/TombLauncher.Localization/Localization/de-DE.axaml
@@ -535,5 +535,6 @@
     <system:String x:Key="MANIFEST_FETCH_FAILURE">Aktualisierungsinformationen der Wissensdatenbank konnten nicht abgerufen werden</system:String>
     <system:String x:Key="KB_DOWNLOAD_FAILURE">Fehler beim Herunterladen der Wissensdatenbank</system:String>
     <system:String x:Key="KB_ERROR_TRANSIENT_NOTICE">Hierbei handelt es sich in der Regel um vorübergehende Fehler, die sicher ignoriert werden können.</system:String>
+    <system:String x:Key="AUTOMATIC_ENGINE_DETECTION_FAILED_SET_MANUALLY">Tomb Launcher konnte die Engine für dieses Level nicht automatisch erkennen. Legen Sie sie manuell fest, um die Schaltfläche „Spielen" zu aktivieren.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -543,5 +543,6 @@
     <system:String x:Key="MANIFEST_FETCH_FAILURE">Unable to retrieve Knowledge Base update information</system:String>
     <system:String x:Key="KB_DOWNLOAD_FAILURE">Error downloading the Knowledge Base database</system:String>
     <system:String x:Key="KB_ERROR_TRANSIENT_NOTICE">These are generally transient errors and can be safely ignored.</system:String>
+    <system:String x:Key="AUTOMATIC_ENGINE_DETECTION_FAILED_SET_MANUALLY">Tomb Launcher could not automatically detect the engine for this level. Set it manually to enable the Play button.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/es-ES.axaml
+++ b/src/TombLauncher.Localization/Localization/es-ES.axaml
@@ -535,5 +535,6 @@
     <system:String x:Key="MANIFEST_FETCH_FAILURE">No se pudo recuperar la información de actualización de la base de conocimientos</system:String>
     <system:String x:Key="KB_DOWNLOAD_FAILURE">Error al descargar la base de conocimientos</system:String>
     <system:String x:Key="KB_ERROR_TRANSIENT_NOTICE">Por lo general, son errores transitorios que pueden ignorarse sin problema.</system:String>
+    <system:String x:Key="AUTOMATIC_ENGINE_DETECTION_FAILED_SET_MANUALLY">Tomb Launcher no pudo detectar automáticamente el motor de este nivel. Configúrelo manualmente para activar el botón Jugar.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/fr-FR.axaml
+++ b/src/TombLauncher.Localization/Localization/fr-FR.axaml
@@ -535,5 +535,6 @@
     <system:String x:Key="MANIFEST_FETCH_FAILURE">Impossible de récupérer les informations de mise à jour de la base de connaissances</system:String>
     <system:String x:Key="KB_DOWNLOAD_FAILURE">Erreur lors du téléchargement de la base de connaissances</system:String>
     <system:String x:Key="KB_ERROR_TRANSIENT_NOTICE">Il s'agit généralement d'erreurs temporaires qui peuvent être ignorées sans risque.</system:String>
+    <system:String x:Key="AUTOMATIC_ENGINE_DETECTION_FAILED_SET_MANUALLY">Tomb Launcher n'a pas pu détecter automatiquement le moteur de ce niveau. Définissez-le manuellement pour activer le bouton Jouer.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -542,5 +542,6 @@
     <system:String x:Key="MANIFEST_FETCH_FAILURE">Impossibile recuperare le informazioni di aggiornamento della Knowledge Base</system:String>
     <system:String x:Key="KB_DOWNLOAD_FAILURE">Errore nel download del database della Knowledge Base</system:String>
     <system:String x:Key="KB_ERROR_TRANSIENT_NOTICE">Generalmente si tratta di errori temporanei che puoi ignorare tranquillamente.</system:String>
+    <system:String x:Key="AUTOMATIC_ENGINE_DETECTION_FAILED_SET_MANUALLY">Tomb Launcher non è riuscito a rilevare automaticamente l'engine di questo livello. Impostalo manualmente per abilitare il pulsante.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/pl-PL.axaml
+++ b/src/TombLauncher.Localization/Localization/pl-PL.axaml
@@ -535,5 +535,6 @@
     <system:String x:Key="MANIFEST_FETCH_FAILURE">Nie można pobrać informacji o aktualizacji bazy wiedzy</system:String>
     <system:String x:Key="KB_DOWNLOAD_FAILURE">Błąd podczas pobierania bazy wiedzy</system:String>
     <system:String x:Key="KB_ERROR_TRANSIENT_NOTICE">Są to zazwyczaj błędy przejściowe, które można bezpiecznie zignorować.</system:String>
+    <system:String x:Key="AUTOMATIC_ENGINE_DETECTION_FAILED_SET_MANUALLY">Tomb Launcher nie mógł automatycznie wykryć silnika dla tego poziomu. Ustaw go ręcznie, aby włączyć przycisk Graj.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher/Services/GameWithStatsService.cs
+++ b/src/TombLauncher/Services/GameWithStatsService.cs
@@ -153,7 +153,7 @@ public class GameWithStatsService : IViewService, IDisposable
 
     public bool CanPlayGame(GameWithStatsViewModel game)
     {
-        return game.GameMetadata.IsInstalled;
+        return game.GameMetadata.IsInstalled && game.GameMetadata.GameEngine != GameEngine.Unknown;
     }
 
     public bool CanLaunchSetup(GameWithStatsViewModel game)

--- a/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
@@ -33,6 +33,7 @@ public partial class GameDetailsViewModel : PageViewModel
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanOpenChat))]
     [NotifyPropertyChangedFor(nameof(EngineSupportState))]
+    [NotifyPropertyChangedFor(nameof(PlayButtonTooltip))]
     private GameWithStatsViewModel _game = null!;
 
     [ObservableProperty] private int _descriptionFontSize = 18;
@@ -43,6 +44,19 @@ public partial class GameDetailsViewModel : PageViewModel
     public List<string> IgnoredFolders { get; set; } = [];
     private readonly GameDetailsService _gameDetailsService;
     private readonly IPlatformSpecificFeatures _platformSpecificFeatures;
+
+    public string PlayButtonTooltip
+    {
+        get
+        {
+            if (Game?.GameMetadata.GameEngine == GameEngine.Unknown)
+            {
+                return "AUTOMATIC_ENGINE_DETECTION_FAILED_SET_MANUALLY".GetLocalizedString();
+            }
+
+            return "PLAY".GetLocalizedString();
+        }
+    }
 
     public override async Task OnNavigatedTo(object? parameter)
     {

--- a/src/TombLauncher/Views/GameBar.axaml
+++ b/src/TombLauncher/Views/GameBar.axaml
@@ -109,6 +109,9 @@
                 <Button Height="44"
                         Padding="16 0"
                         IsVisible="{Binding Game.GameMetadata.InstallDirectory, Converter={x:Static ObjectConverters.IsNotNull}}"
+                        IsEnabled="{Binding Game.GameMetadata.GameEngine, Converter={x:Static ObjectConverters.NotEqual}, ConverterParameter={x:Static enums:GameEngine.Unknown}}"
+                        ToolTip.Tip="{Binding PlayButtonTooltip}"
+                        ToolTip.ShowOnDisabled="True"
                         Classes="btn-success"
                         Command="{Binding Game.PlayCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="8">


### PR DESCRIPTION
The Play button in GameBar is now disabled when the game engine is
GameEngine.Unknown, and shows a localized tooltip instructing the user
to set the engine manually in the Game Launch options page. CanPlayGame()
enforces the same guard so the context menu item is also blocked.

Localization added in all seven languages. Two KB FAQ entries document
the pre-1.4.0 loading-state behaviour and the new greyed-out button,
with version range metadata for accurate RAG retrieval.

Also registers a TLS 1.3-only named HttpClient for KbUpdateService to
work around a SiteGround WAF rule that blocks .NET's default TLS
fingerprint on Windows.

Closes #155

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>