### PR TITLE
fix(ui): hide cancel button when no download is in progress (#154)

### DIFF
--- a/src/TombLauncher/ValueConverters/GameInstallStatusMultiConverter.cs
+++ b/src/TombLauncher/ValueConverters/GameInstallStatusMultiConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using TombLauncher.Contracts.Enums;
+using TombLauncher.ViewModels;
+
+namespace TombLauncher.ValueConverters;
+
+public class GameInstallStatusMultiConverter : IMultiValueConverter
+{
+    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values[0] is not InstallProgressViewModel)
+            return false;
+        var installStatus = (InstallStatus?)values[1];
+
+        return installStatus is InstallStatus.Indeterminate or InstallStatus.Downloading or InstallStatus.Installing;
+    }
+}

--- a/src/TombLauncher/Views/GameSearchResultCardView.axaml
+++ b/src/TombLauncher/Views/GameSearchResultCardView.axaml
@@ -10,7 +10,6 @@
              xmlns:valueConverters="clr-namespace:TombLauncher.ValueConverters"
              xmlns:downloaders="clr-namespace:TombLauncher.Contracts.Downloaders;assembly=TombLauncher.Contracts"
              xmlns:views="clr-namespace:TombLauncher.Views"
-             xmlns:enums="clr-namespace:TombLauncher.Contracts.Enums;assembly=TombLauncher.Contracts"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="TombLauncher.Views.GameSearchResultCardView"
              x:DataType="viewModels:MultiSourceGameSearchResultMetadataViewModel">
@@ -20,6 +19,7 @@
     <UserControl.Resources>
         <valueConverters:StringEmptyToLocalizedStringConverter x:Key="DownloadToolTipConverter" NotEmptyValue="Download" 
                                                                EmptyValue="This level was found by one or more downloaders, but no download link is available."/>
+        <valueConverters:GameInstallStatusMultiConverter x:Key="GameInstallStatusMultiConverter" />
     </UserControl.Resources>
 
     <UserControl.Styles>
@@ -231,8 +231,14 @@
                 <controls:IconOnlyButton Icon="CloseLine"
                                          Classes="btn-danger"
                                          ToolTip.Tip="{loc:Translate CANCEL}"
-                                         IsVisible="{Binding InstallProgress.InstallStatus, Converter={x:Static ObjectConverters.NotEqual}, ConverterParameter={x:Static enums:InstallStatus.Completed}}"
-                                         Command="{Binding CancelInstallCommand}" />
+                                         Command="{Binding CancelInstallCommand}" >
+                    <controls:IconOnlyButton.IsVisible>
+                        <MultiBinding Converter="{StaticResource GameInstallStatusMultiConverter}">
+                            <Binding Path="InstallProgress" />
+                            <Binding Path="InstallProgress?.InstallStatus"></Binding>
+                        </MultiBinding>
+                    </controls:IconOnlyButton.IsVisible>
+                </controls:IconOnlyButton>
                 <!-- Kebab button: choose specific download source -->
                 <controls:IconOnlyButton Icon="MoreLine"
                                          Classes="btn-secondary"


### PR DESCRIPTION
Replaces the NotEqual/Completed binding with a MultiBinding and a dedicated GameInstallStatusMultiConverter that returns true only when InstallStatus is Indeterminate, Downloading, or Installing. This correctly handles the null InstallProgress case and the Canceled state.