### PR TITLE
chore: update NuGet packages to latest versions

### DIFF
--- a/src/TombLauncher.Ai/TombLauncher.Ai.csproj
+++ b/src/TombLauncher.Ai/TombLauncher.Ai.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.1.72" />
-      <PackageReference Include="Markdig" Version="1.1.2" />
-      <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
-      <PackageReference Include="Microsoft.SemanticKernel" Version="1.74.0" />
-      <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.75.0" />
+      <PackageReference Include="Dapper" Version="2.1.79" />
+      <PackageReference Include="Markdig" Version="1.2.0" />
+      <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+      <PackageReference Include="Microsoft.SemanticKernel" Version="1.76.0" />
+      <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.76.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -36,6 +36,6 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
     </ItemGroup>
 </Project>

--- a/src/TombLauncher.Controls/TombLauncher.Controls.csproj
+++ b/src/TombLauncher.Controls/TombLauncher.Controls.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia" Version="11.3.12" />
-      <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
-      <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
+      <PackageReference Include="Avalonia" Version="11.3.15" />
+      <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
+      <PackageReference Include="Avalonia.Desktop" Version="11.3.15" />
       <PackageReference Include="IconPacks.Avalonia.RemixIcon" Version="1.3.1" />
       <PackageReference Include="JamSoft.AvaloniaUI.Dialogs" Version="1.4.2" />
       <PackageReference Include="Lipis.Flags.Avalonia" Version="11.3.2" />

--- a/src/TombLauncher.Core/TombLauncher.Core.csproj
+++ b/src/TombLauncher.Core/TombLauncher.Core.csproj
@@ -13,10 +13,10 @@
 
     <ItemGroup>
       <PackageReference Include="Hardware.Info" Version="101.1.1.1" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
       <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />
-      <PackageReference Include="NuGet.Versioning" Version="7.3.1" />
+      <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
       <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
       <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/TombLauncher.Data/TombLauncher.Data.csproj
+++ b/src/TombLauncher.Data/TombLauncher.Data.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.2" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TombLauncher.Integrations/TombLauncher.Integrations.csproj
+++ b/src/TombLauncher.Integrations/TombLauncher.Integrations.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TombLauncher.KnowledgeBase.Embedder/TombLauncher.KnowledgeBase.Embedder.csproj
+++ b/src/TombLauncher.KnowledgeBase.Embedder/TombLauncher.KnowledgeBase.Embedder.csproj
@@ -8,12 +8,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-      <PackageReference Include="SSH.NET" Version="2024.2.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+      <PackageReference Include="SSH.NET" Version="2025.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TombLauncher.Localization/TombLauncher.Localization.csproj
+++ b/src/TombLauncher.Localization/TombLauncher.Localization.csproj
@@ -45,8 +45,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.12" />
-      <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+      <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.15" />
+      <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TombLauncher/TombLauncher.csproj
+++ b/src/TombLauncher/TombLauncher.csproj
@@ -25,41 +25,41 @@
         <PackageReference Include="AngleSharp" Version="1.4.0" />
         <PackageReference Include="AngleSharp.XPath" Version="2.0.6" />
         <PackageReference Include="AsyncImageLoader.Avalonia" Version="3.7.0" />
-        <PackageReference Include="Avalonia" Version="11.3.12" />
+        <PackageReference Include="Avalonia" Version="11.3.15" />
         <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.12" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.15" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.15" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.15" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.12" />
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-        <PackageReference Include="Fastenshtein" Version="1.0.11" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.15" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+        <PackageReference Include="Fastenshtein" Version="1.0.12" />
         <PackageReference Include="IconPacks.Avalonia.RemixIcon" Version="1.3.1" />
         <PackageReference Include="JamSoft.AvaloniaUI.Dialogs" Version="1.4.2" />
-        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc6.1" />
+        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.4" />
         <PackageReference Include="Markdown.Avalonia" Version="11.0.2" />
         <PackageReference Include="Markdown.Avalonia.Html" Version="11.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.8" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
-        <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="3.0.4" />
-        <PackageReference Include="NetSparkleUpdater.UI.Avalonia" Version="3.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+        <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="3.1.0" />
+        <PackageReference Include="NetSparkleUpdater.UI.Avalonia" Version="3.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Octokit" Version="14.0.0" />
-        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-        <PackageReference Include="Svg.Controls.Avalonia" Version="11.3.9.4" />
+        <PackageReference Include="Svg.Controls.Avalonia" Version="11.3.9.5" />
         <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
         <PackageReference Include="UTF.Unknown" Version="2.6.0" />
-        <PackageReference Include="Xaml.Behaviors.Interactions" Version="11.3.9" />
+        <PackageReference Include="Xaml.Behaviors.Interactions" Version="11.3.9.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/TombLauncher.Tests/TombLauncher.Tests.csproj
+++ b/tests/TombLauncher.Tests/TombLauncher.Tests.csproj
@@ -10,12 +10,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
- Avalonia packages: 11.3.12 → 11.3.15 (DataGrid stays at 11.3.13, last available in 11.x)
- Microsoft.Extensions.*: aligned to 10.0.8 across all projects
- Microsoft.EntityFrameworkCore.*: 10.0.2 → 10.0.8
- Microsoft.SemanticKernel + Connectors.OpenAI: 1.74/1.75 → 1.76.0 (aligned)
- LiveChartsCore.SkiaSharpView.Avalonia: 2.0.0-rc6.1 → 2.0.4 (stable)
- NetSparkleUpdater: 3.0.4 → 3.1.0
- SSH.NET: 2024.2.0 → 2025.1.0
- CommunityToolkit.Mvvm: 8.4.0 → 8.4.2
- Serilog: 4.3.0 → 4.3.1
- Svg.Controls.Avalonia: 11.3.9.4 → 11.3.9.5
- Xaml.Behaviors.Interactions: 11.3.9 → 11.3.9.5
- Microsoft.NET.Test.Sdk: 18.0.1 → 18.5.1
- coverlet.collector: 6.0.4 → 10.0.1
- Various other minor patch bumps

Closes #167 