### PR TITLE
feat(ai): make LLM temperature configurable from AI settings

### DIFF
--- a/src/TombLauncher.Ai/Configuration/AiConfig.cs
+++ b/src/TombLauncher.Ai/Configuration/AiConfig.cs
@@ -12,4 +12,5 @@ public class AiConfig : IAiConfig
     public string? Endpoint { get; set; }
     public string? ApiKey { get; set; }
     public AiBackendType BackendType { get; set; }
+    public double? Temperature { get; set; }
 }

--- a/src/TombLauncher.Ai/Configuration/IAiConfig.cs
+++ b/src/TombLauncher.Ai/Configuration/IAiConfig.cs
@@ -12,4 +12,5 @@ public interface IAiConfig
     string Endpoint { get; set; }
     string? ApiKey { get; set; }
     AiBackendType BackendType { get; set; }
+    double? Temperature { get; set; }
 }

--- a/src/TombLauncher.Ai/Extensions/EmbedderRegistrationExtensions.cs
+++ b/src/TombLauncher.Ai/Extensions/EmbedderRegistrationExtensions.cs
@@ -55,10 +55,15 @@ public static class EmbedderRegistrationExtensions
                     .GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>())
             .AddScoped<TroubleshootingContextService>()
             .AddScoped<IChatCompletionServiceLoader, OpenAiCompatibleChatCompletionServiceLoader>()
-            .AddScoped<PromptExecutionSettings>(_ => new PromptExecutionSettings()
+            .AddScoped<PromptExecutionSettings>(sp =>
             {
-                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
-                ExtensionData = new Dictionary<string, object> { ["temperature"] = 0.65 }
+                var config = sp.GetRequiredService<IAiConfig>();
+                return new PromptExecutionSettings()
+                {
+                    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                    ExtensionData = new Dictionary<string, object>
+                        { ["temperature"] = config.Temperature.GetValueOrDefault(0.65) }
+                };
             })
             .AddSingleton<OpenAIClient>(sp =>
             {

--- a/src/TombLauncher.Core/Dtos/Configuration/CoreSettings.cs
+++ b/src/TombLauncher.Core/Dtos/Configuration/CoreSettings.cs
@@ -11,4 +11,4 @@ public record GameDetailsCoreSettings(string UnzipFallbackMethod, (string Comman
 
 public record ApplicationCoreSettings(string GitHubLink, string WebsiteLink, CultureInfo ApplicationLanguage, int RandomGameMaxRerolls, string DatabasePath);
 
-public record AiCoreSettings(bool IsEnabled, string ModelId, AiBackendType BackendType, string Endpoint, string? ApiKey, string EmbeddingModelId);
+public record AiCoreSettings(bool IsEnabled, string ModelId, AiBackendType BackendType, string Endpoint, string? ApiKey, string EmbeddingModelId, double Temperature);

--- a/src/TombLauncher.Localization/Localization/cs-CZ.axaml
+++ b/src/TombLauncher.Localization/Localization/cs-CZ.axaml
@@ -550,5 +550,7 @@
     <system:String x:Key="GAMEPAD_TOOL_NOT_VALID">Nástroj nenalezen nebo neplatný.</system:String>
     <system:String x:Key="BROWSE">Procházet</system:String>
     <system:String x:Key="RESET_DEFAULT">Obnovit výchozí</system:String>
+    <system:String x:Key="LLM_TEMPERATURE">Teplota modelu</system:String>
+    <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Teplota řídí „kreativitu" modelu. Čím vyšší hodnota, tím nepředvídatelnější výstup. Příliš nízká hodnota způsobí, že Laura bude mluvit robotičtěji, ale bude fakticky přesnější, zatímco příliš vysoká hodnota vygeneruje fantazijnější text, ale může způsobit halucinace – Laura by mohla informace zcela vymýšlet.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/de-DE.axaml
+++ b/src/TombLauncher.Localization/Localization/de-DE.axaml
@@ -550,5 +550,7 @@
     <system:String x:Key="GAMEPAD_TOOL_NOT_VALID">Tool nicht gefunden oder ungültig.</system:String>
     <system:String x:Key="BROWSE">Durchsuchen</system:String>
     <system:String x:Key="RESET_DEFAULT">Auf Standard zurücksetzen</system:String>
+    <system:String x:Key="LLM_TEMPERATURE">Modelltemperatur</system:String>
+    <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Die Temperatur steuert die „Kreativität" des Modells. Je höher der Wert, desto unvorhersehbarer die Ausgabe. Ein zu niedriger Wert lässt Laura roboterhafter, aber sachlich genauer sprechen, während ein zu hoher Wert fantasievollere Texte erzeugt, aber Halluzinationen verursachen kann – Laura könnte Informationen völlig erfinden.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -558,5 +558,7 @@
     <system:String x:Key="GAMEPAD_TOOL_NOT_VALID">Tool not found or not valid.</system:String>
     <system:String x:Key="BROWSE">Browse</system:String>
     <system:String x:Key="RESET_DEFAULT">Reset to default</system:String>
+    <system:String x:Key="LLM_TEMPERATURE">Model temperature</system:String>
+    <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Temperature controls the model's "creativity". The higher the value, the more unpredictable the output. A value that is too low will make Laura speak in a more robotic but factually accurate way, while a value that is too high will generate more imaginative text, but may cause hallucinations — Laura might make up information entirely.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/es-ES.axaml
+++ b/src/TombLauncher.Localization/Localization/es-ES.axaml
@@ -550,5 +550,7 @@
     <system:String x:Key="GAMEPAD_TOOL_NOT_VALID">Herramienta no encontrada o no válida.</system:String>
     <system:String x:Key="BROWSE">Examinar</system:String>
     <system:String x:Key="RESET_DEFAULT">Restablecer valor predeterminado</system:String>
+    <system:String x:Key="LLM_TEMPERATURE">Temperatura del modelo</system:String>
+    <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">La temperatura controla la «creatividad» del modelo. Cuanto más alto sea el valor, más imprevisible será la salida. Un valor demasiado bajo hará que Laura hable de forma más robótica pero factualmente más precisa, mientras que un valor demasiado alto generará texto más imaginativo, pero puede causar alucinaciones: Laura podría inventarse información de la nada.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/fr-FR.axaml
+++ b/src/TombLauncher.Localization/Localization/fr-FR.axaml
@@ -550,5 +550,7 @@
     <system:String x:Key="GAMEPAD_TOOL_NOT_VALID">Outil introuvable ou non valide.</system:String>
     <system:String x:Key="BROWSE">Parcourir</system:String>
     <system:String x:Key="RESET_DEFAULT">Réinitialiser par défaut</system:String>
+    <system:String x:Key="LLM_TEMPERATURE">Température du modèle</system:String>
+    <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">La température contrôle la « créativité » du modèle. Plus la valeur est élevée, plus la sortie est imprévisible. Une valeur trop basse rendra Laura plus robotique mais factuellement plus précise, tandis qu'une valeur trop élevée générera un texte plus imaginatif, mais pourra provoquer des hallucinations : Laura pourrait inventer des informations de toutes pièces.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -557,5 +557,7 @@
     <system:String x:Key="GAMEPAD_TOOL_NOT_VALID">Strumento non trovato o non valido.</system:String>
     <system:String x:Key="BROWSE">Sfoglia</system:String>
     <system:String x:Key="RESET_DEFAULT">Ripristina il valore predefinito</system:String>
+    <system:String x:Key="LLM_TEMPERATURE">Temperatura modello</system:String>
+    <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">La temperatura determina il livello di "creatività" del modello. Più è alta, più è imprevedibile il testo in output. Un valore troppo basso farà sì che Laura parli in maniera più robotica ma fattualmente più accurata, mentre un valore troppo alto generà testo più fantasioso, ma potrebbe generare allucinazioni, ossia Laura potrebbe inventare informazioni di sana pianta.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/pl-PL.axaml
+++ b/src/TombLauncher.Localization/Localization/pl-PL.axaml
@@ -550,5 +550,7 @@
     <system:String x:Key="GAMEPAD_TOOL_NOT_VALID">Narzędzie nie znalezione lub nieprawidłowe.</system:String>
     <system:String x:Key="BROWSE">Przeglądaj</system:String>
     <system:String x:Key="RESET_DEFAULT">Przywróć domyślne</system:String>
+    <system:String x:Key="LLM_TEMPERATURE">Temperatura modelu</system:String>
+    <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Temperatura kontroluje „kreatywność" modelu. Im wyższa wartość, tym bardziej nieprzewidywalne odpowiedzi. Zbyt niska wartość sprawi, że Laura będzie mówić bardziej mechanicznie, lecz będzie dokładniejsza pod względem faktycznym, natomiast zbyt wysoka wartość wygeneruje bardziej pomysłowy tekst, ale może powodować halucynacje – Laura mogłaby wymyślać informacje z powietrza.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher/Configuration/LayeredAppConfiguration.cs
+++ b/src/TombLauncher/Configuration/LayeredAppConfiguration.cs
@@ -92,7 +92,8 @@ public class LayeredAppConfiguration : ILayeredAppConfiguration
         KnowledgeBasePath = Defaults.Ai.KnowledgeBasePath,
         ApiKey = User.Ai.ApiKey.Coalesce(Defaults.Ai.ApiKey),
         Endpoint = User.Ai.Endpoint,
-        BackendType = User.Ai.BackendType.Coalesce(Defaults.Ai.BackendType)
+        BackendType = User.Ai.BackendType.Coalesce(Defaults.Ai.BackendType),
+        Temperature = User.Ai.Temperature.Coalesce(Defaults.Ai.Temperature)
     };
 
     public IIntegrationsConfig Integrations => new IntegrationsConfig()

--- a/src/TombLauncher/Services/SettingsProvider.cs
+++ b/src/TombLauncher/Services/SettingsProvider.cs
@@ -128,7 +128,9 @@ public class SettingsProvider : ISettingsProvider
     public AiCoreSettings GetAiCoreSettings()
     {
         var aiSettings = _appConfiguration.Ai;
-        return new AiCoreSettings(aiSettings.IsAiEnabled, aiSettings.ModelId!, aiSettings.BackendType, aiSettings.Endpoint, aiSettings.ApiKey, aiSettings.EmbeddingModelId!);
+        return new AiCoreSettings(aiSettings.IsAiEnabled, aiSettings.ModelId!, aiSettings.BackendType,
+            aiSettings.Endpoint, aiSettings.ApiKey, aiSettings.EmbeddingModelId!,
+            aiSettings.Temperature.GetValueOrDefault(0.65));
     }
 
     public IPlatformSpecificFeatures PlatformSpecificFeatures { get; }

--- a/src/TombLauncher/ViewModels/Pages/Settings/AiSettingsViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/Settings/AiSettingsViewModel.cs
@@ -36,20 +36,43 @@ public partial class AiSettingsViewModel : SettingsSectionViewModelBase
             { CheckResultMessage = "", Status = ServiceCheckStatus.Unspecified };
     }
 
-    [ObservableProperty] private ObservableCollection<AiModelViewModel>? _availableModels;
-    [ObservableProperty] private AiModelViewModel? _selectedModel;
+    [ObservableProperty]
+    public partial ObservableCollection<AiModelViewModel>? AvailableModels { get; set; }
+
+    [ObservableProperty]
+    public partial AiModelViewModel? SelectedModel { get; set; }
+
     private string? _savedModelId;
     public string? SavedModelId { set => _savedModelId = value; }
-    [ObservableProperty] private bool _isEnabled;
-    [ObservableProperty] private List<AiBackendType> _availableBackendTypes;
-    [ObservableProperty] private AiBackendType _selectedBackendType;
-    [ObservableProperty] private string _endpoint = string.Empty;
-    [ObservableProperty] private string? _apiKey;
-    [ObservableProperty] private ServiceCheckViewModel _apiServiceCheckViewModel;
-    [ObservableProperty] private ServiceCheckViewModel _embeddingServiceCheckViewModel;
-    [ObservableProperty] private string _embeddingModelId;
+    [ObservableProperty]
+    public partial bool IsEnabled { get; set; }
 
-    [ObservableProperty] private ServiceCheckViewModel _kbServiceCheckViewModel;
+    [ObservableProperty]
+    public partial List<AiBackendType> AvailableBackendTypes { get; set; }
+
+    [ObservableProperty]
+    public partial AiBackendType SelectedBackendType { get; set; }
+
+    [ObservableProperty]
+    public partial string Endpoint { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string? ApiKey { get; set; }
+
+    [ObservableProperty]
+    public partial ServiceCheckViewModel ApiServiceCheckViewModel { get; set; }
+
+    [ObservableProperty]
+    public partial ServiceCheckViewModel EmbeddingServiceCheckViewModel { get; set; }
+
+    [ObservableProperty]
+    public partial string EmbeddingModelId { get; set; }
+
+    [ObservableProperty]
+    public partial ServiceCheckViewModel KbServiceCheckViewModel { get; set; }
+    
+    [ObservableProperty]
+    public partial double Temperature { get; set; }
 
     private readonly AiBackendFactory _backendFactory;
     private readonly AiMapper _modelMapper;
@@ -194,6 +217,7 @@ public partial class AiSettingsViewModel : SettingsSectionViewModelBase
         userConfig.Ai.Endpoint = Endpoint;
         userConfig.Ai.ApiKey = ApiKey;
         userConfig.Ai.BackendType = SelectedBackendType;
+        userConfig.Ai.Temperature = Temperature;
         base.ApplyTo(userConfig);
     }
 }

--- a/src/TombLauncher/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/SettingsPageViewModel.cs
@@ -149,6 +149,7 @@ public partial class SettingsPageViewModel : PageViewModel, IChangeTracking
                 ApiKey = aiCoreSettings.ApiKey,
                 SelectedBackendType = aiCoreSettings.BackendType,
                 Endpoint = aiCoreSettings.Endpoint,
+                Temperature = aiCoreSettings.Temperature
             };
 
             var compat = _appConfiguration.Compatibility;

--- a/src/TombLauncher/Views/AiSettingsView.axaml
+++ b/src/TombLauncher/Views/AiSettingsView.axaml
@@ -34,6 +34,18 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
+            
+            <DockPanel LastChildFill="True">
+                <controls:Infotip DockPanel.Dock="Right"
+                                  Header="{loc:Translate LLM_TEMPERATURE}"
+                                  ToolTipContent="{loc:Translate LLM_TEMPERATURE_DESCRIPTION}" />
+                <TextBlock Text="{loc:Translate LLM_TEMPERATURE}" />
+            </DockPanel>
+            <NumericUpDown Value="{Binding Temperature}"
+                           Minimum="0" Maximum="2"
+                           Increment="0.05"
+                           FormatString="0.00" />
+            
             <TextBlock Text="{loc:Translate AI_BACKEND_ENDPOINT}" />
             <DockPanel LastChildFill="True">
                 <views:ServiceCheckView DockPanel.Dock="Right" DataContext="{Binding ApiServiceCheckViewModel}" />

--- a/src/TombLauncher/appsettings.json
+++ b/src/TombLauncher/appsettings.json
@@ -101,7 +101,8 @@
     "KnowledgeBasePath": "KnowledgeBase/kb_embeddings.db",
     "ModelId": null,
     "EmbeddingModelId": "text-embedding-nomic-embed-text-v1.5@f32",
-    "Endpoint": "http://localhost:11434/v1"
+    "Endpoint": "http://localhost:11434/v1",
+    "Temperature": 0.65
   },
   "Integrations": {
     "DiscordAppId": "1504231949890224302",


### PR DESCRIPTION
Exposes the previously hardcoded temperature (0.65) as a user-facing setting in the AI settings page. Adds a NumericUpDown slider (range 0–2, step 0.05) and localizes the new keys in all 7 supported languages.

Closes #119