### PR TITLE
feat(borderless): add per-game borderless window fix for classic games

### DIFF
--- a/src/TombLauncher.Contracts/Downloaders/IGameMetadataLite.cs
+++ b/src/TombLauncher.Contracts/Downloaders/IGameMetadataLite.cs
@@ -31,4 +31,5 @@ public interface IGameMetadataLite
     string? CompatibilityToolPath { get; set; }
     string? TitlePicUrl { get; set; }
     string? InstalledFromLink { get; set; }
+    bool EnableBorderlessFix { get; set; }
 }

--- a/src/TombLauncher.Core/Dtos/GameMetadataDto.cs
+++ b/src/TombLauncher.Core/Dtos/GameMetadataDto.cs
@@ -33,5 +33,6 @@ public class GameMetadataDto : IGameMetadata
     public string? CompatibilityToolPath { get; set; }
     public string? TitlePicUrl { get; set; }
     public string? InstalledFromLink { get; set; }
+    public bool EnableBorderlessFix { get; set; }
     public List<IEnvironmentVariable> ExtraEnvVars { get; set; } = [];
 }

--- a/src/TombLauncher.Core/PlatformSpecific/BorderlessWindowHelper.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/BorderlessWindowHelper.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace TombLauncher.Core.PlatformSpecific;
+
+public static class BorderlessWindowHelper
+{
+    public static void Apply(Process process, int width, int height)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        Task.Run(() => PollWindow(process, width, height));
+    }
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern nint GetWindowLongPtr(nint hWnd, int nIndex);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern nint SetWindowLongPtr(nint hWnd, int nIndex, nint dwNewLong);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+    
+    private const int MsCheck = 100;
+    private const int MaxIterations = 100;
+
+    private const int GwlStyle = -16;
+
+    private const nint WsCaptions   = 0x00C00000;
+    private const nint WsThickframe = 0x00040000;
+    private const nint WsMinimizebox = 0x00020000;
+    private const nint WsMaximizebox = 0x00010000;
+    private const nint WsSysmenu    = 0x00080000;
+
+    private const uint SwpFramechanged = 0x0020;
+    private const uint SwpShowwindow   = 0x0040;
+    private const uint SwpNozorder     = 0x0004;
+    private const uint SwpNoactivate   = 0x0010;
+    private static async Task PollWindow(Process process, int width, int height)
+    {
+        try
+        {
+            for (var i = 0; i < MaxIterations; i++)
+            {
+                var windowHandle = process.MainWindowHandle;
+                if (windowHandle != 0)
+                {
+                    var style = GetWindowLongPtr(windowHandle, GwlStyle);
+                    if (style == 0 && Marshal.GetLastWin32Error() == 5) return; // ERROR_ACCESS_DENIED
+                    SetWindowLongPtr(windowHandle, GwlStyle,
+                        style & ~(WsCaptions | WsThickframe | WsMinimizebox | WsMaximizebox | WsSysmenu));
+                    SetWindowPos(windowHandle, 0, 0, 0, width, height,
+                        SwpFramechanged | SwpShowwindow | SwpNozorder | SwpNoactivate);
+                    return;
+                }
+
+                await Task.Delay(MsCheck);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Process already exited. Ignore
+        }
+    }
+}

--- a/src/TombLauncher.Core/PlatformSpecific/BorderlessWindowHelper.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/BorderlessWindowHelper.cs
@@ -1,10 +1,32 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using TombLauncher.Core.Extensions;
 
 namespace TombLauncher.Core.PlatformSpecific;
 
 public static class BorderlessWindowHelper
 {
+    public static async Task ApplyWineFix(string winePrefix, ILogger logger)
+    {
+        var startInfo = new ProcessStartInfo("wine")
+        {
+            Arguments = @"reg add ""HKCU\Software\Wine\X11 Driver"" /v Decorated /t REG_SZ /d N /f",
+            CreateNoWindow = true,
+            UseShellExecute = true
+        };
+        if (winePrefix.IsNotNullOrWhiteSpace())
+            startInfo.Environment["WINEPREFIX"] = winePrefix;
+
+        var process = Process.Start(startInfo);
+        if (process == null)
+        {
+            logger.LogWarning("Wine reg add process was null");
+            return;
+        }
+        await process.WaitForExitAsync(new CancellationTokenSource(WineTimeout).Token);
+    }
+    
     public static void Apply(Process process, int width, int height)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
@@ -35,6 +57,7 @@ public static class BorderlessWindowHelper
     private const uint SwpShowwindow   = 0x0040;
     private const uint SwpNozorder     = 0x0004;
     private const uint SwpNoactivate   = 0x0010;
+    private const int WineTimeout = 5000;
     private static async Task PollWindow(Process process, int width, int height)
     {
         try

--- a/src/TombLauncher.Core/PlatformSpecific/BorderlessWindowHelper.cs
+++ b/src/TombLauncher.Core/PlatformSpecific/BorderlessWindowHelper.cs
@@ -7,13 +7,15 @@ namespace TombLauncher.Core.PlatformSpecific;
 
 public static class BorderlessWindowHelper
 {
-    public static async Task ApplyWineFix(string winePrefix, ILogger logger)
+    public static async Task ApplyWineFix(string? winePrefix, ILogger logger)
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return;
         var startInfo = new ProcessStartInfo("wine")
         {
             Arguments = @"reg add ""HKCU\Software\Wine\X11 Driver"" /v Decorated /t REG_SZ /d N /f",
             CreateNoWindow = true,
-            UseShellExecute = true
+            UseShellExecute = false
         };
         if (winePrefix.IsNotNullOrWhiteSpace())
             startInfo.Environment["WINEPREFIX"] = winePrefix;

--- a/src/TombLauncher.Data/Database/Services/GameDataService.cs
+++ b/src/TombLauncher.Data/Database/Services/GameDataService.cs
@@ -62,6 +62,7 @@ public class GameDataService
             entity.AuthorFullName = game.AuthorFullName;
             entity.IsFavourite = game.IsFavourite;
             entity.IsCompleted = game.IsCompleted;
+            entity.EnableBorderlessFix = game.EnableBorderlessFix;
             _dbContext.Games.Update(entity);
         }
 

--- a/src/TombLauncher.Data/Mapping/GameMapper.cs
+++ b/src/TombLauncher.Data/Mapping/GameMapper.cs
@@ -47,7 +47,8 @@ public class GameMapper
             CompatibilityTool = game.CompatibilityTool,
             CompatibilityToolPath = game.CompatibilityToolPath,
             ExtraEnvVars = _environmentVariableMapper.ToDtos(game.EnvironmentVariables).ToList(),
-            InstalledFromLink = game.InstalledFromLink?.Link
+            InstalledFromLink = game.InstalledFromLink?.Link,
+            EnableBorderlessFix = game.EnableBorderlessFix
         };
     }
 
@@ -77,7 +78,8 @@ public class GameMapper
             CompatibilityTool = dto.CompatibilityTool,
             CompatibilityToolPath = dto.CompatibilityToolPath,
             CompatibilityPrefixPath = dto.CompatibilityPrefixPath,
-            TitlePicUrl = dto.TitlePicUrl
+            TitlePicUrl = dto.TitlePicUrl,
+            EnableBorderlessFix = dto.EnableBorderlessFix
         };
     }
 }

--- a/src/TombLauncher.Data/Migrations/20260521073454_AddEnableBorderlessFix.Designer.cs
+++ b/src/TombLauncher.Data/Migrations/20260521073454_AddEnableBorderlessFix.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TombLauncher.Data.Database;
 
@@ -10,9 +11,11 @@ using TombLauncher.Data.Database;
 namespace TombLauncher.Data.Migrations
 {
     [DbContext(typeof(TombLauncherDbContext))]
-    partial class TombLauncherDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260521073454_AddEnableBorderlessFix")]
+    partial class AddEnableBorderlessFix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/src/TombLauncher.Data/Migrations/20260521073454_AddEnableBorderlessFix.cs
+++ b/src/TombLauncher.Data/Migrations/20260521073454_AddEnableBorderlessFix.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TombLauncher.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEnableBorderlessFix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "EnableBorderlessFix",
+                table: "Games",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EnableBorderlessFix",
+                table: "Games");
+        }
+    }
+}

--- a/src/TombLauncher.Data/Models/Game.cs
+++ b/src/TombLauncher.Data/Models/Game.cs
@@ -31,4 +31,5 @@ public class Game
     public string? CompatibilityToolPath { get; set; }
     public List<GameEnvironmentVariable> EnvironmentVariables { get; set; } = [];
     public string? TitlePicUrl { get; set; }
+    public bool EnableBorderlessFix { get; set; }
 }

--- a/src/TombLauncher.KnowledgeBase.Embedder/Input/01_common_issues_and_solutions/01_common_issues_and_solutions.md
+++ b/src/TombLauncher.KnowledgeBase.Embedder/Input/01_common_issues_and_solutions/01_common_issues_and_solutions.md
@@ -39,19 +39,13 @@ if that doesn't work either, just rename/delete the Pix Folder and the game will
 
 ## Why is the window title visible when playing in full-screen mode?
 
-This issue occurs in modern Operating Systems (Windows 8, 8.1, 10) only
-with older Custom Levels. Luckily the newer ones have not this problem
-anymore.
+This issue occurs in modern Operating Systems (Windows 8, 8.1, 10) only with older Custom Levels. Luckily the newer ones have not this problem anymore.
 
 To solve the issue just download and apply this fix: https://community.pcgamingwiki.com/files/file/82-tomb-raider-series-fullscreen-border-fix/
 
-A future version of Tomb Launcher will allow you to fix this issue without applying that fix, but as of version 1.1.0 this is not yet available.
+Tomb Launcher can apply this fix automatically for you as of version 1.5.0. From the game details page, select the "Patches" button (the one with the nurse icon) and click on "Toggle fullscreen border fix". A small icon representing a window will appear on the game bar, indicating the patch is enabled.
 
-You may want to know that this Fix doesn't patch your game. It just writes some informations in Windows. Specifically, it creates an SDB file in the folder "C:\Windows\apppatch\CustomSDB\" and also writes some data in the Registry key [HKEY\_LOCAL\_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Custom]
-
-These informations are name-based instructions, in other words you inform your system that every time you run an EXE with those specific names, he must remove the border.
-
-Unfortunately there are some inconveniences, for example if you decide to play in windowed mode the border is removed anyway. Luckily the Fix can be installed and uninstalled in a simple click, so you can apply or remove it at convenience. Or even better, since it's a name-based fix, you can rename the EXE to bypass it temporally.
+This fix does not modify the Tomb Raider executable: it just tells your operating system not to draw the title bar on top of the game.
 
 ## Why does the game appear horizontally stretched? Why does Lara appear short and large?
 

--- a/src/TombLauncher.Localization/Localization/cs-CZ.axaml
+++ b/src/TombLauncher.Localization/Localization/cs-CZ.axaml
@@ -552,5 +552,7 @@
     <system:String x:Key="RESET_DEFAULT">Obnovit výchozí</system:String>
     <system:String x:Key="LLM_TEMPERATURE">Teplota modelu</system:String>
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Teplota řídí „kreativitu" modelu. Čím vyšší hodnota, tím nepředvídatelnější výstup. Příliš nízká hodnota způsobí, že Laura bude mluvit robotičtěji, ale bude fakticky přesnější, zatímco příliš vysoká hodnota vygeneruje fantazijnější text, ale může způsobit halucinace – Laura by mohla informace zcela vymýšlet.</system:String>
+    <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Přepnout opravu okraje celé obrazovky</system:String>
+    <system:String x:Key="BORDER_FIX_ENABLED">Oprava okraje je aktivována.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/de-DE.axaml
+++ b/src/TombLauncher.Localization/Localization/de-DE.axaml
@@ -552,5 +552,7 @@
     <system:String x:Key="RESET_DEFAULT">Auf Standard zurücksetzen</system:String>
     <system:String x:Key="LLM_TEMPERATURE">Modelltemperatur</system:String>
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Die Temperatur steuert die „Kreativität" des Modells. Je höher der Wert, desto unvorhersehbarer die Ausgabe. Ein zu niedriger Wert lässt Laura roboterhafter, aber sachlich genauer sprechen, während ein zu hoher Wert fantasievollere Texte erzeugt, aber Halluzinationen verursachen kann – Laura könnte Informationen völlig erfinden.</system:String>
+    <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Randlosen-Fix aktivieren/deaktivieren</system:String>
+    <system:String x:Key="BORDER_FIX_ENABLED">Rahmen-Fix ist aktiviert.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -560,5 +560,7 @@
     <system:String x:Key="RESET_DEFAULT">Reset to default</system:String>
     <system:String x:Key="LLM_TEMPERATURE">Model temperature</system:String>
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Temperature controls the model's "creativity". The higher the value, the more unpredictable the output. A value that is too low will make Laura speak in a more robotic but factually accurate way, while a value that is too high will generate more imaginative text, but may cause hallucinations — Laura might make up information entirely.</system:String>
+    <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Toggle fullscreen border fix</system:String>
+    <system:String x:Key="BORDER_FIX_ENABLED">Border fix is enabled.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/es-ES.axaml
+++ b/src/TombLauncher.Localization/Localization/es-ES.axaml
@@ -552,5 +552,7 @@
     <system:String x:Key="RESET_DEFAULT">Restablecer valor predeterminado</system:String>
     <system:String x:Key="LLM_TEMPERATURE">Temperatura del modelo</system:String>
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">La temperatura controla la «creatividad» del modelo. Cuanto más alto sea el valor, más imprevisible será la salida. Un valor demasiado bajo hará que Laura hable de forma más robótica pero factualmente más precisa, mientras que un valor demasiado alto generará texto más imaginativo, pero puede causar alucinaciones: Laura podría inventarse información de la nada.</system:String>
+    <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Activar/desactivar corrección de bordes en pantalla completa</system:String>
+    <system:String x:Key="BORDER_FIX_ENABLED">La corrección de bordes está activada.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/fr-FR.axaml
+++ b/src/TombLauncher.Localization/Localization/fr-FR.axaml
@@ -552,5 +552,7 @@
     <system:String x:Key="RESET_DEFAULT">Réinitialiser par défaut</system:String>
     <system:String x:Key="LLM_TEMPERATURE">Température du modèle</system:String>
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">La température contrôle la « créativité » du modèle. Plus la valeur est élevée, plus la sortie est imprévisible. Une valeur trop basse rendra Laura plus robotique mais factuellement plus précise, tandis qu'une valeur trop élevée générera un texte plus imaginatif, mais pourra provoquer des hallucinations : Laura pourrait inventer des informations de toutes pièces.</system:String>
+    <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Activer/désactiver la correction des bordures plein écran</system:String>
+    <system:String x:Key="BORDER_FIX_ENABLED">La correction des bordures est activée.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -559,5 +559,7 @@
     <system:String x:Key="RESET_DEFAULT">Ripristina il valore predefinito</system:String>
     <system:String x:Key="LLM_TEMPERATURE">Temperatura modello</system:String>
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">La temperatura determina il livello di "creatività" del modello. Più è alta, più è imprevedibile il testo in output. Un valore troppo basso farà sì che Laura parli in maniera più robotica ma fattualmente più accurata, mentre un valore troppo alto generà testo più fantasioso, ma potrebbe generare allucinazioni, ossia Laura potrebbe inventare informazioni di sana pianta.</system:String>
+    <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Abilita/disabilita fix border fullscreen</system:String>
+    <system:String x:Key="BORDER_FIX_ENABLED">Il border fix è attivato.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/pl-PL.axaml
+++ b/src/TombLauncher.Localization/Localization/pl-PL.axaml
@@ -552,5 +552,7 @@
     <system:String x:Key="RESET_DEFAULT">Przywróć domyślne</system:String>
     <system:String x:Key="LLM_TEMPERATURE">Temperatura modelu</system:String>
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Temperatura kontroluje „kreatywność" modelu. Im wyższa wartość, tym bardziej nieprzewidywalne odpowiedzi. Zbyt niska wartość sprawi, że Laura będzie mówić bardziej mechanicznie, lecz będzie dokładniejsza pod względem faktycznym, natomiast zbyt wysoka wartość wygeneruje bardziej pomysłowy tekst, ale może powodować halucynacje – Laura mogłaby wymyślać informacje z powietrza.</system:String>
+    <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Włącz/wyłącz poprawkę obramowania pełnego ekranu</system:String>
+    <system:String x:Key="BORDER_FIX_ENABLED">Poprawka obramowania jest włączona.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher/App.axaml.cs
+++ b/src/TombLauncher/App.axaml.cs
@@ -7,7 +7,6 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
-using Avalonia.Styling;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using IconPacks.Avalonia.RemixIcon;
@@ -22,12 +21,9 @@ using TombLauncher.Contracts.Enums;
 using TombLauncher.Contracts.Localization;
 using TombLauncher.Contracts.PlatformSpecific;
 using TombLauncher.Contracts.Settings;
-using TombLauncher.Core.Exceptions;
 using TombLauncher.Core.Extensions;
-using TombLauncher.Core.PlatformSpecific;
 using TombLauncher.Core.Utils;
 using TombLauncher.Data.Database;
-using TombLauncher.Data.Database.Services;
 using TombLauncher.Extensions;
 using TombLauncher.Gamepad.Extensions;
 using TombLauncher.Integrations.Extensions;
@@ -73,7 +69,7 @@ public class App : Application
                     ((IDisposable)Log.Logger).Dispose();
                 };
 
-                Dispatcher.UIThread.UnhandledException += OnUnhandledException;
+                Dispatcher.UIThread.UnhandledException += AppUtils.OnUnhandledException;
                 var resourceDictionary = new ResourceDictionary();
 
                 var kbUpdateResult = KbUpdateResult.Success();
@@ -154,51 +150,10 @@ public class App : Application
         localizationManager.ChangeLanguage(applicationLanguage);
     }
 
-    private void OnUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
-    {
-        AppCrashDataService? appCrashDataService = null;
-        try
-        {
-            appCrashDataService = Ioc.Default.GetRequiredService<AppCrashDataService>();
-        }
-        catch (InvalidOperationException)
-        {
-            // Service provider not configured yet.
-            // Log to console/debug as fallback
-            Console.Error.WriteLine("Unhandled exception occurred before IoC container was initialized.");
-            Console.Error.WriteLine(e.Exception);
-            // Cannot use database logging
-        }
-
-        var exception = e.Exception;
-        if (exception is TargetInvocationException tie)
-        {
-            exception = tie.InnerException;
-        }
-
-        Console.Error.WriteLine("--- ORIGINAL FATAL CRASH ---");
-        Console.Error.WriteLine(exception);
-        Console.Error.WriteLine("----------------------------");
-
-        if (appCrashDataService != null)
-        {
-            if (exception != null) appCrashDataService.InsertAppCrash(exception);
-            var welcomePageService = Ioc.Default.GetRequiredService<WelcomePageService>();
-            welcomePageService.HandleNotNotifiedCrashes();
-        }
-
-        e.Handled = true;
-        if (exception?.GetType() == typeof(AppRestartRequestedException))
-        {
-            // WTF?! How did you get in here?
-            e.Handled = false;
-        }
-    }
-
     private async Task ShowMainWindow(SplashScreen splashScreen, MainWindow mainWindow, KbUpdateResult kbUpdateResult)
     {
         splashScreen.Close();
-        ApplyInitialSettings();
+        AppUtils.ApplyInitialSettings();
         mainWindow.Show();
         var updateService = Ioc.Default.GetRequiredService<UpdateService>();
         await updateService.StartAsync();
@@ -257,21 +212,5 @@ public class App : Application
         Log.Logger.Information("Service initialization complete");
 
         await Task.CompletedTask;
-    }
-
-    private void ApplyInitialSettings()
-    {
-        var settingsProvider = Ioc.Default.GetRequiredService<ISettingsProvider>();
-        var themeManager = Ioc.Default.GetRequiredService<ThemeManager>();
-
-        var applicationTheme = settingsProvider.GetAppearanceSettings().ApplicationTheme;
-        themeManager.ApplyTheme(applicationTheme);
-
-        var baseVariant = ThemeVariant.Dark;
-        if (!string.IsNullOrEmpty(applicationTheme) && applicationTheme.Contains("Light"))
-        {
-            baseVariant = ThemeVariant.Light;
-        }
-        AppUtils.ChangeTheme(baseVariant);
     }
 }

--- a/src/TombLauncher/Mappers/GameMetadataMapper.cs
+++ b/src/TombLauncher/Mappers/GameMetadataMapper.cs
@@ -62,7 +62,9 @@ public class GameMetadataMapper
             CompatibilityPrefixPath = dto.CompatibilityPrefixPath,
             CompatibilityTool = dto.CompatibilityTool,
             CompatibilityToolPath = dto.CompatibilityToolPath,
-            ExtraEnvVars = dto.ExtraEnvVars.OfType<EnvironmentVariableDto>().ToList()
+            ExtraEnvVars = dto.ExtraEnvVars.OfType<EnvironmentVariableDto>().ToList(),
+            EnableBorderlessFix = dto.EnableBorderlessFix,
+            InstalledFromLink = dto.InstalledFromLink
         };
     }
 
@@ -102,7 +104,9 @@ public class GameMetadataMapper
             CompatibilityPrefixPath = viewModel.CompatibilityPrefixPath,
             CompatibilityTool = viewModel.CompatibilityTool,
             CompatibilityToolPath = viewModel.CompatibilityToolPath,
-            ExtraEnvVars = viewModel.ExtraEnvVars.Cast<IEnvironmentVariable>().ToList()
+            ExtraEnvVars = viewModel.ExtraEnvVars.Cast<IEnvironmentVariable>().ToList(),
+            EnableBorderlessFix = viewModel.EnableBorderlessFix,
+            InstalledFromLink = viewModel.InstalledFromLink
         };
     }
 

--- a/src/TombLauncher/Services/GameDetailsService.cs
+++ b/src/TombLauncher/Services/GameDetailsService.cs
@@ -160,4 +160,12 @@ public class GameDetailsService : IViewService
             return false;
         return _gamepadSupportMatrix.GetGamepadSupport(vm.GameEngine);
     }
+
+    public async Task ToggleBorderlessFix(GameMetadataViewModel game)
+    {
+        game.EnableBorderlessFix = !game.EnableBorderlessFix;
+
+        var dto = _gameMapper.ToDto(game);
+        await _gameDataService.UpsertGame(dto);
+    }
 }

--- a/src/TombLauncher/Services/GameWithStatsService.cs
+++ b/src/TombLauncher/Services/GameWithStatsService.cs
@@ -88,7 +88,7 @@ public class GameWithStatsService : IViewService, IDisposable
     private readonly GameDataService _gameDataService;
     private readonly PlaySessionDataService _playSessionDataService;
     private readonly ISavegameRepository _savegameRepository;
-    public NavigationManager NavigationManager => ViewContext.NavigationManager;
+    private NavigationManager NavigationManager => ViewContext.NavigationManager;
     private FileSystemWatcher? _watcher;
     private readonly bool _backupEnabled;
     private readonly int? _numberOfSavesToKeep;
@@ -111,7 +111,7 @@ public class GameWithStatsService : IViewService, IDisposable
         await OpenGame(game);
     }
 
-    public void PlayGame(GameWithStatsViewModel game)
+    public async Task PlayGame(GameWithStatsViewModel game)
     {
         var currentPage = NavigationManager.CurrentPage as INavigationTarget;
         currentPage?.SetBusy("STARTING_GAMENAME".GetLocalizedString(game.GameMetadata.Title));
@@ -125,14 +125,14 @@ public class GameWithStatsService : IViewService, IDisposable
                 _discordService.UpdateStatus(new RichPresenceDto()
                 {
                     LevelName = game.GameMetadata.Title, 
-                    AuthorName = game.GameMetadata.Author,
+                    AuthorName = game.GameMetadata.Author ?? "",
                     WebsiteUrl = "https://tomblauncher.app", 
                     WebsiteCaption = "Try Tomb Launcher",
                     LevelUrl = game.GameMetadata.InstalledFromLink,
                     Engine = game.GameMetadata.GameEngine
                 });
             }
-            LaunchProcess(game, game.GameMetadata.ExecutablePath, true);
+            await LaunchProcess(game, game.GameMetadata.ExecutablePath, true);
         }
     }
 
@@ -172,7 +172,7 @@ public class GameWithStatsService : IViewService, IDisposable
     {
         var gameViewModel = await GetGameById(gameId);
         await OpenGame(gameViewModel);
-        PlayGame(gameViewModel!);
+        await PlayGame(gameViewModel!);
     }
 
     private async Task<GameWithStatsViewModel?> GetGameById(int gameId)
@@ -294,27 +294,27 @@ public class GameWithStatsService : IViewService, IDisposable
         }
     }
 
-    public void LaunchSetup(GameWithStatsViewModel game)
+    public async Task LaunchSetup(GameWithStatsViewModel game)
     {
         var currentPage = NavigationManager.CurrentPage as INavigationTarget;
         currentPage?.SetBusy("LAUNCHING_SETUP_FOR_GAMENAME".GetLocalizedString(game.GameMetadata.Title));
         if (game.GameMetadata.SetupExecutable != null)
         {
-            LaunchProcess(game, game.GameMetadata.SetupExecutable, false, game.GameMetadata.SetupExecutableArgs);
+            await LaunchProcess(game, game.GameMetadata.SetupExecutable, false, game.GameMetadata.SetupExecutableArgs);
         }
     }
 
-    public void LaunchCommunitySetup(GameWithStatsViewModel game)
+    public async Task LaunchCommunitySetup(GameWithStatsViewModel game)
     {
         var currentPage = NavigationManager.CurrentPage as INavigationTarget;
         currentPage?.SetBusy("LAUNCHING_COMMUNITY_PATCH_SETUP_FOR_GAMENAME".GetLocalizedString(game.GameMetadata.Title));
         if (game.GameMetadata.CommunitySetupExecutable != null)
         {
-            LaunchProcess(game, game.GameMetadata.CommunitySetupExecutable);
+            await LaunchProcess(game, game.GameMetadata.CommunitySetupExecutable);
         }
     }
 
-    private void LaunchProcess(GameWithStatsViewModel game, string executable, bool trackPlayTime = false,
+    private async Task LaunchProcess(GameWithStatsViewModel game, string executable, bool trackPlayTime = false,
         string? arguments = null)
     {
         LaunchGamepadService(game.GameMetadata.GameEngine);
@@ -405,12 +405,28 @@ public class GameWithStatsService : IViewService, IDisposable
             };
         }
 
+        if (game.GameMetadata.EnableBorderlessFix)
+        {
+            await BorderlessWindowHelper.ApplyWineFix(winePrefix, _logger);
+        }
+
         process.Start();
+        
+        if (game.GameMetadata.EnableBorderlessFix)
+        {
+            var screenBounds = AppUtils.GetPrimaryScreenBounds();
+            if (screenBounds == null)
+                _logger.LogWarning("Requested widescreen fix, but unable to retrieve primary screen bounds!");
+            else
+                BorderlessWindowHelper.Apply(process, screenBounds.Value.Width, screenBounds.Value.Height);
+        }
 
         if (!process.StartInfo.UseShellExecute)
         {
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
+            if (process.StartInfo.RedirectStandardOutput)
+                process.BeginOutputReadLine();
+            if (process.StartInfo.RedirectStandardError)
+                process.BeginErrorReadLine();
         }
     }
 

--- a/src/TombLauncher/Utils/AppUtils.cs
+++ b/src/TombLauncher/Utils/AppUtils.cs
@@ -36,6 +36,7 @@ namespace TombLauncher.Utils;
 public static class AppUtils
 {
     public static string[] LogFileNamePatterns => ["LAST_CRASH*", "TENLog*.txt", "TR1X.log", "TR2X.log"];
+    
     public static IClipboard GetClipboard()
     {
         var applicationLifetime = Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
@@ -250,5 +251,15 @@ public static class AppUtils
             // WTF?! How did you get in here?
             e.Handled = false;
         }
+    }
+
+    public static PixelRect? GetPrimaryScreenBounds()
+    {
+        if (Application.Current?.ApplicationLifetime is ClassicDesktopStyleApplicationLifetime applicationLifetime)
+        {
+            return applicationLifetime.MainWindow?.Screens.Primary?.Bounds;
+        }
+
+        return null;
     }
 }

--- a/src/TombLauncher/Utils/EnumUtils.cs
+++ b/src/TombLauncher/Utils/EnumUtils.cs
@@ -18,5 +18,8 @@ public static class EnumUtils
     /// Engine variants like <see cref="GameEngine.Tr1x"/> encode their base engine in the lower 6 bits
     /// (e.g. Tr1x = TombRaider1 | variant bits), so masking with 0b111111 isolates the base.
     /// </summary>
-    public static GameEngine GetBaseEngine(this GameEngine engine) => engine & (GameEngine)0b111111;
+    public static GameEngine GetBaseEngine(this GameEngine engine) => engine & ClassicEngines;
+
+    public static GameEngine ClassicEngines => GameEngine.TombRaider1 | GameEngine.TombRaider2 |
+                                               GameEngine.TombRaider3 | GameEngine.TombRaider4 | GameEngine.TombRaider5;
 }

--- a/src/TombLauncher/ViewModels/CommandViewModel.cs
+++ b/src/TombLauncher/ViewModels/CommandViewModel.cs
@@ -7,8 +7,29 @@ namespace TombLauncher.ViewModels;
 
 public partial class CommandViewModel : ViewModelBase, ITopBarCommand
 {
-    [ObservableProperty] private ICommand _command = null!;
-    [ObservableProperty] private Enum? _icon;
-    [ObservableProperty] private string _tooltip = null!;
-    [ObservableProperty] private string _text = null!;
+    [ObservableProperty]
+    public partial ICommand Command { get; set; } = null!;
+
+    [ObservableProperty]
+    public partial Enum? Icon { get; set; }
+
+    [ObservableProperty]
+    public partial string Tooltip { get; set; } = null!;
+
+    [ObservableProperty]
+    public partial string Text { get; set; } = null!;
+    
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsChecked))]
+    public partial bool IsCheckable { get; set; }
+
+    public bool IsChecked
+    {
+        get
+        {
+            if (!IsCheckable) return false;
+            return field;
+        }
+        set => SetProperty(ref field, value);
+    }
 }

--- a/src/TombLauncher/ViewModels/CommandViewModel.cs
+++ b/src/TombLauncher/ViewModels/CommandViewModel.cs
@@ -18,18 +18,4 @@ public partial class CommandViewModel : ViewModelBase, ITopBarCommand
 
     [ObservableProperty]
     public partial string Text { get; set; } = null!;
-    
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsChecked))]
-    public partial bool IsCheckable { get; set; }
-
-    public bool IsChecked
-    {
-        get
-        {
-            if (!IsCheckable) return false;
-            return field;
-        }
-        set => SetProperty(ref field, value);
-    }
 }

--- a/src/TombLauncher/ViewModels/GameMetadataViewModel.cs
+++ b/src/TombLauncher/ViewModels/GameMetadataViewModel.cs
@@ -11,31 +11,84 @@ namespace TombLauncher.ViewModels;
 public partial class GameMetadataViewModel : ViewModelBase, IGameMetadataLite
 {
     public int Id { get; set; }
-    [ObservableProperty] private string _title = string.Empty;
-    [ObservableProperty] private string _author = string.Empty;
-    [ObservableProperty] private DateTime? _releaseDate;
-    [ObservableProperty] private DateTime? _installDate;
-    [ObservableProperty] private GameEngine _gameEngine;
-    [ObservableProperty] private string? _setting;
-    [ObservableProperty] private GameLength _length;
-    [ObservableProperty] private GameDifficulty _difficulty;
-    [ObservableProperty] private string? _installDirectory;
-    [ObservableProperty] private string? _executablePath;
-    [ObservableProperty] private string _description = string.Empty;
-    [ObservableProperty] private Bitmap? _titlePic;
-    [ObservableProperty] private string? _authorFullName;
-    [ObservableProperty] private bool _isInstalled;
-    [ObservableProperty] private string? _setupExecutable;
-    [ObservableProperty] private string? _setupExecutableArgs;
-    [ObservableProperty] private string? _communitySetupExecutable;
-    [ObservableProperty] private bool _isCompleted;
-    [ObservableProperty] private bool _isFavourite;
-    [ObservableProperty] private string? _installedFromSiteDisplayName;
-    [ObservableProperty] private string? _compatibilityPrefixPath;
-    [ObservableProperty] private CompatibilityTool _compatibilityTool;
-    [ObservableProperty] private string? _compatibilityToolPath;
-    [ObservableProperty] private string? _titlePicUrl;
-    [ObservableProperty] private string? _installedFromLink;
+    [ObservableProperty]
+    public partial string Title { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string? Author { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial DateTime? ReleaseDate { get; set; }
+
+    [ObservableProperty]
+    public partial DateTime? InstallDate { get; set; }
+
+    [ObservableProperty]
+    public partial GameEngine GameEngine { get; set; }
+
+    [ObservableProperty]
+    public partial string? Setting { get; set; }
+
+    [ObservableProperty]
+    public partial GameLength Length { get; set; }
+
+    [ObservableProperty]
+    public partial GameDifficulty Difficulty { get; set; }
+
+    [ObservableProperty]
+    public partial string? InstallDirectory { get; set; }
+
+    [ObservableProperty]
+    public partial string? ExecutablePath { get; set; }
+
+    [ObservableProperty]
+    public partial string Description { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial Bitmap? TitlePic { get; set; }
+
+    [ObservableProperty]
+    public partial string? AuthorFullName { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsInstalled { get; set; }
+
+    [ObservableProperty]
+    public partial string? SetupExecutable { get; set; }
+
+    [ObservableProperty]
+    public partial string? SetupExecutableArgs { get; set; }
+
+    [ObservableProperty]
+    public partial string? CommunitySetupExecutable { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsCompleted { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsFavourite { get; set; }
+
+    [ObservableProperty]
+    public partial string? InstalledFromSiteDisplayName { get; set; }
+
+    [ObservableProperty]
+    public partial string? CompatibilityPrefixPath { get; set; }
+
+    [ObservableProperty]
+    public partial CompatibilityTool CompatibilityTool { get; set; }
+
+    [ObservableProperty]
+    public partial string? CompatibilityToolPath { get; set; }
+
+    [ObservableProperty]
+    public partial string? TitlePicUrl { get; set; }
+
+    [ObservableProperty]
+    public partial string? InstalledFromLink { get; set; }
+
     public List<EnvironmentVariableDto> ExtraEnvVars { get; set; } = [];
     public Guid Guid { get; set; }
+    
+    [ObservableProperty]
+    public partial bool EnableBorderlessFix { get; set; }
 }

--- a/src/TombLauncher/ViewModels/GameWithStatsViewModel.cs
+++ b/src/TombLauncher/ViewModels/GameWithStatsViewModel.cs
@@ -25,9 +25,9 @@ public partial class GameWithStatsViewModel : ViewModelBase
     [ObservableProperty] private DateTime? _lastPlayed;
     [ObservableProperty] private bool _areCommandsVisible;
     [RelayCommand(CanExecute = nameof(CanPlay))]
-    private void Play()
+    private async Task Play()
     {
-        _gameWithStatsService.PlayGame(this);
+        await _gameWithStatsService.PlayGame(this);
     }
 
     private bool CanPlay() => _gameWithStatsService.CanPlayGame(this);
@@ -39,9 +39,9 @@ public partial class GameWithStatsViewModel : ViewModelBase
     }
 
     [RelayCommand(CanExecute = nameof(CanLaunchSetup))]
-    private void LaunchSetup()
+    private async Task LaunchSetup()
     {
-        _gameWithStatsService.LaunchSetup(this);
+        await _gameWithStatsService.LaunchSetup(this);
     }
 
     private bool CanLaunchSetup()
@@ -50,9 +50,9 @@ public partial class GameWithStatsViewModel : ViewModelBase
     }
 
     [RelayCommand(CanExecute = nameof(CanLaunchCommunitySetup))]
-    private void LaunchCommunitySetup()
+    private async Task LaunchCommunitySetup()
     {
-        _gameWithStatsService.LaunchCommunitySetup(this);
+        await _gameWithStatsService.LaunchCommunitySetup(this);
     }
 
     private bool CanLaunchCommunitySetup()

--- a/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -6,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using EnumsNET;
 using IconPacks.Avalonia.RemixIcon;
 using TombLauncher.Contracts.Enums;
 using TombLauncher.Contracts.PlatformSpecific;
@@ -13,6 +15,7 @@ using TombLauncher.Core.Extensions;
 using TombLauncher.Core.PlatformSpecific;
 using TombLauncher.Localization.Extensions;
 using TombLauncher.Services;
+using TombLauncher.Utils;
 
 namespace TombLauncher.ViewModels.Pages;
 
@@ -26,10 +29,11 @@ public partial class GameDetailsViewModel : PageViewModel
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(ReadWalkthroughCommand))]
-    private bool _askForConfirmationBeforeOpeningWalkthrough;
-
-    [ObservableProperty] private ObservableCollection<CommandViewModel> _setupCommands = [];
-    [ObservableProperty] private ObservableCollection<FileInfo> _documentationFiles = [];
+    public partial bool AskForConfirmationBeforeOpeningWalkthrough { get; set; }
+    [ObservableProperty]
+    public partial ObservableCollection<CommandViewModel> SetupCommands { get; set; } = [];
+    [ObservableProperty]
+    public partial ObservableCollection<FileInfo> DocumentationFiles { get; set; } = [];
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanOpenChat))]
@@ -39,8 +43,11 @@ public partial class GameDetailsViewModel : PageViewModel
     private GameWithStatsViewModel _game = null!;
 
     [ObservableProperty] private int _descriptionFontSize = 18;
-    [ObservableProperty] private ObservableCollection<GameLinkViewModel> _walkthroughLinks = [];
-    [ObservableProperty] private ObservableCollection<CommandViewModel> _patchers = [];
+    [ObservableProperty]
+    public partial ObservableCollection<GameLinkViewModel> WalkthroughLinks { get; set; } = [];
+    [ObservableProperty]
+    public partial ObservableCollection<CommandViewModel> Patchers { get; set; } = [];
+
     public bool CanOpenChat => _gameDetailsService.CanOpenChat(Game?.GameMetadata);
     public List<string> EnabledPatterns { get; set; } = [];
     public List<string> IgnoredFolders { get; set; } = [];
@@ -169,6 +176,19 @@ public partial class GameDetailsViewModel : PageViewModel
                 Command = new AsyncRelayCommand(() => _gameDetailsService.OpenTrxNativePatcher(Game.GameMetadata)),
                 Text = "CONVERT_TO_NATIVE_EXECUTABLE".GetLocalizedString(),
                 Icon = PackIconRemixIconKind.UbuntuLine
+            });
+        }
+
+        if (Game.GameMetadata.GameEngine.GetBaseEngine().HasAnyFlags(EnumUtils.ClassicEngines))
+        {
+            patchers.Add(new CommandViewModel()
+            {
+                Command = new AsyncRelayCommand(() => { Console.WriteLine("Implement me!");
+                    return Task.CompletedTask;
+                }), // TODO
+                Icon = PackIconRemixIconKind.Window2Fill,
+                Text = "ENABLE_FULLSCREEN_BORDER_FIX".GetLocalizedString(),
+                IsCheckable = true
             });
         }
 

--- a/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
@@ -185,9 +185,7 @@ public partial class GameDetailsViewModel : PageViewModel
             {
                 Command = new AsyncRelayCommand(ToggleBorderlessFix),
                 Icon = PackIconRemixIconKind.Window2Fill,
-                Text = "TOGGLE_FULLSCREEN_BORDER_FIX".GetLocalizedString(),
-                IsCheckable = true,
-                IsChecked = Game.GameMetadata.EnableBorderlessFix
+                Text = "TOGGLE_FULLSCREEN_BORDER_FIX".GetLocalizedString()
             };
             
             patchers.Add(command);

--- a/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/GameDetailsViewModel.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -12,7 +11,6 @@ using IconPacks.Avalonia.RemixIcon;
 using TombLauncher.Contracts.Enums;
 using TombLauncher.Contracts.PlatformSpecific;
 using TombLauncher.Core.Extensions;
-using TombLauncher.Core.PlatformSpecific;
 using TombLauncher.Localization.Extensions;
 using TombLauncher.Services;
 using TombLauncher.Utils;
@@ -40,9 +38,10 @@ public partial class GameDetailsViewModel : PageViewModel
     [NotifyPropertyChangedFor(nameof(EngineSupportState))]
     [NotifyPropertyChangedFor(nameof(PlayButtonTooltip))]
     [NotifyPropertyChangedFor(nameof(NativeGamepadSupport))]
-    private GameWithStatsViewModel _game = null!;
+    public partial GameWithStatsViewModel Game { get; set; } = null!;
 
-    [ObservableProperty] private int _descriptionFontSize = 18;
+    [ObservableProperty]
+    public partial int DescriptionFontSize { get; set; } = 18;
     [ObservableProperty]
     public partial ObservableCollection<GameLinkViewModel> WalkthroughLinks { get; set; } = [];
     [ObservableProperty]
@@ -111,7 +110,8 @@ public partial class GameDetailsViewModel : PageViewModel
             await _gameDetailsService.OpenWalkthrough(link.Link, AskForConfirmationBeforeOpeningWalkthrough);
     }
 
-    [ObservableProperty] private ICommand? _installCommand;
+    [ObservableProperty]
+    public partial ICommand? InstallCommand { get; set; }
 
     [RelayCommand]
     private async Task OpenLaunchOptions() => await _gameDetailsService.OpenLaunchOptions(this);
@@ -181,18 +181,24 @@ public partial class GameDetailsViewModel : PageViewModel
 
         if (Game.GameMetadata.GameEngine.GetBaseEngine().HasAnyFlags(EnumUtils.ClassicEngines))
         {
-            patchers.Add(new CommandViewModel()
+            var command = new CommandViewModel()
             {
-                Command = new AsyncRelayCommand(() => { Console.WriteLine("Implement me!");
-                    return Task.CompletedTask;
-                }), // TODO
+                Command = new AsyncRelayCommand(ToggleBorderlessFix),
                 Icon = PackIconRemixIconKind.Window2Fill,
-                Text = "ENABLE_FULLSCREEN_BORDER_FIX".GetLocalizedString(),
-                IsCheckable = true
-            });
+                Text = "TOGGLE_FULLSCREEN_BORDER_FIX".GetLocalizedString(),
+                IsCheckable = true,
+                IsChecked = Game.GameMetadata.EnableBorderlessFix
+            };
+            
+            patchers.Add(command);
         }
 
         Patchers = patchers;
+    }
+
+    private async Task ToggleBorderlessFix()
+    {
+        await _gameDetailsService.ToggleBorderlessFix(Game.GameMetadata);
     }
 
     [RelayCommand]

--- a/src/TombLauncher/Views/GameBar.axaml
+++ b/src/TombLauncher/Views/GameBar.axaml
@@ -199,6 +199,13 @@
                                              Background="Transparent"
                                              IsVisible="{Binding Game.GameMetadata.IsInstalled}"
                                              ToolTip.Tip="{Binding NativeGamepadSupport, Converter={StaticResource GamepadSupportToTooltipConverter}}" />
+                
+                <iconPacks:PackIconRemixIcon Kind="Window2Fill" 
+                                             Width="22" Height="22"
+                                             VerticalAlignment="Center"
+                                             Background="Transparent"
+                                             IsVisible="{Binding Game.GameMetadata.EnableBorderlessFix}"
+                                             ToolTip.Tip="{loc:Translate BORDER_FIX_ENABLED}" />
 
                 <!-- Last played: label + date, grouped together -->
                 <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center"


### PR DESCRIPTION

Implements an opt-in per-game setting that removes window decorations from
classic Tomb Raider games after launch, achieving a borderless windowed
(fake fullscreen) result.

- Data layer: add EnableBorderlessFix to Game entity, GameMetadataDto,
  GameMetadataViewModel, and all mappers; EF migration with default false
- Windows: post-launch P/Invoke poll (GetWindowLongPtr/SetWindowLongPtr/
  SetWindowPos) to strip WS_CAPTION|WS_THICKFRAME|WS_MINIMIZEBOX|
  WS_MAXIMIZEBOX|WS_SYSMENU; silently skips on ERROR_ACCESS_DENIED (admin
  games); DPI-unaware env var via __COMPAT_LAYER to prevent scaling issues
- Linux/Wine: pre-launch wine reg add to HKCU\Software\Wine\X11 Driver
  to disable window decorations; Proton unaffected
- UI: toggle entry in the Patches menu (GameBar), restricted to classic
  engines; indicator icon in GameBar when fix is active
- Launch pipeline: made fully async; BeginOutputReadLine/BeginErrorReadLine
  guarded by redirect flags
- Localization: TOGGLE_FULLSCREEN_BORDER_FIX and BORDER_FIX_ENABLED in
  all 7 supported languages
- KnowledgeBase: document the fix in the common issues guide

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Closes #134 