### PR TITLE
feat(gamepad): add gamepad support matrix page (#181)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,23 @@ When in doubt, discuss first and act only when explicitly asked.
 
 Version scheme: `MAJOR.MINOR.PATCH` — bump MINOR for new features, PATCH for bugfix-only releases.
 
+## Commit messages
+
+Use **Conventional Commits** format. The subject line follows `type(scope): description (#issue)`.
+
+The body should list what was added or changed, grouped by area:
+
+```
+feat(scope): short description (#123)
+
+- New class/file: brief purpose
+- Modified X to do Y
+- Localization: added KEY to all N language files
+- ...
+```
+
+Keep the subject under 72 characters. The body uses short bullet points — no prose.
+
 ## Commands
 
 ```bash

--- a/src/TombLauncher.Gamepad/GamepadSupportMatrixEntry.cs
+++ b/src/TombLauncher.Gamepad/GamepadSupportMatrixEntry.cs
@@ -1,0 +1,9 @@
+using TombLauncher.Contracts.Enums;
+
+namespace TombLauncher.Gamepad;
+
+public class GamepadSupportMatrixEntry
+{
+    public GameEngine Engine { get; set; }
+    public bool HasNativeSupport { get; set; }
+}

--- a/src/TombLauncher.Gamepad/SupportMatrix/GamepadSupportMatrix.cs
+++ b/src/TombLauncher.Gamepad/SupportMatrix/GamepadSupportMatrix.cs
@@ -27,4 +27,7 @@ public class GamepadSupportMatrix
     public IReadOnlyDictionary<GameEngine, bool> Matrix { get; }
 
     public bool GetGamepadSupport(GameEngine gameEngine) => Matrix.GetValueOrDefault(gameEngine, false);
+
+    public IEnumerable<GamepadSupportMatrixEntry> GetEntries() => Matrix.Select(kvp => new GamepadSupportMatrixEntry()
+        { Engine = kvp.Key, HasNativeSupport = kvp.Value });
 }

--- a/src/TombLauncher.Localization/Localization/cs-CZ.axaml
+++ b/src/TombLauncher.Localization/Localization/cs-CZ.axaml
@@ -554,5 +554,6 @@
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Teplota řídí „kreativitu" modelu. Čím vyšší hodnota, tím nepředvídatelnější výstup. Příliš nízká hodnota způsobí, že Laura bude mluvit robotičtěji, ale bude fakticky přesnější, zatímco příliš vysoká hodnota vygeneruje fantazijnější text, ale může způsobit halucinace – Laura by mohla informace zcela vymýšlet.</system:String>
     <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Přepnout opravu okraje celé obrazovky</system:String>
     <system:String x:Key="BORDER_FIX_ENABLED">Oprava okraje je aktivována.</system:String>
+    <system:String x:Key="GAMEPAD_SUPPORT">Podpora gamepadu</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/de-DE.axaml
+++ b/src/TombLauncher.Localization/Localization/de-DE.axaml
@@ -554,5 +554,6 @@
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Die Temperatur steuert die „Kreativität" des Modells. Je höher der Wert, desto unvorhersehbarer die Ausgabe. Ein zu niedriger Wert lässt Laura roboterhafter, aber sachlich genauer sprechen, während ein zu hoher Wert fantasievollere Texte erzeugt, aber Halluzinationen verursachen kann – Laura könnte Informationen völlig erfinden.</system:String>
     <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Randlosen-Fix aktivieren/deaktivieren</system:String>
     <system:String x:Key="BORDER_FIX_ENABLED">Rahmen-Fix ist aktiviert.</system:String>
+    <system:String x:Key="GAMEPAD_SUPPORT">Gamepad-Unterstützung</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -562,5 +562,6 @@
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Temperature controls the model's "creativity". The higher the value, the more unpredictable the output. A value that is too low will make Laura speak in a more robotic but factually accurate way, while a value that is too high will generate more imaginative text, but may cause hallucinations — Laura might make up information entirely.</system:String>
     <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Toggle fullscreen border fix</system:String>
     <system:String x:Key="BORDER_FIX_ENABLED">Border fix is enabled.</system:String>
+    <system:String x:Key="GAMEPAD_SUPPORT">Gamepad support</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/es-ES.axaml
+++ b/src/TombLauncher.Localization/Localization/es-ES.axaml
@@ -554,5 +554,6 @@
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">La temperatura controla la «creatividad» del modelo. Cuanto más alto sea el valor, más imprevisible será la salida. Un valor demasiado bajo hará que Laura hable de forma más robótica pero factualmente más precisa, mientras que un valor demasiado alto generará texto más imaginativo, pero puede causar alucinaciones: Laura podría inventarse información de la nada.</system:String>
     <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Activar/desactivar corrección de bordes en pantalla completa</system:String>
     <system:String x:Key="BORDER_FIX_ENABLED">La corrección de bordes está activada.</system:String>
+    <system:String x:Key="GAMEPAD_SUPPORT">Compatibilidad con mando</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/fr-FR.axaml
+++ b/src/TombLauncher.Localization/Localization/fr-FR.axaml
@@ -554,5 +554,6 @@
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">La température contrôle la « créativité » du modèle. Plus la valeur est élevée, plus la sortie est imprévisible. Une valeur trop basse rendra Laura plus robotique mais factuellement plus précise, tandis qu'une valeur trop élevée générera un texte plus imaginatif, mais pourra provoquer des hallucinations : Laura pourrait inventer des informations de toutes pièces.</system:String>
     <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Activer/désactiver la correction des bordures plein écran</system:String>
     <system:String x:Key="BORDER_FIX_ENABLED">La correction des bordures est activée.</system:String>
+    <system:String x:Key="GAMEPAD_SUPPORT">Support manette</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -561,5 +561,6 @@
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">La temperatura determina il livello di "creatività" del modello. Più è alta, più è imprevedibile il testo in output. Un valore troppo basso farà sì che Laura parli in maniera più robotica ma fattualmente più accurata, mentre un valore troppo alto generà testo più fantasioso, ma potrebbe generare allucinazioni, ossia Laura potrebbe inventare informazioni di sana pianta.</system:String>
     <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Abilita/disabilita fix border fullscreen</system:String>
     <system:String x:Key="BORDER_FIX_ENABLED">Il border fix è attivato.</system:String>
+    <system:String x:Key="GAMEPAD_SUPPORT">Supporto controller</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/pl-PL.axaml
+++ b/src/TombLauncher.Localization/Localization/pl-PL.axaml
@@ -554,5 +554,6 @@
     <system:String x:Key="LLM_TEMPERATURE_DESCRIPTION">Temperatura kontroluje „kreatywność" modelu. Im wyższa wartość, tym bardziej nieprzewidywalne odpowiedzi. Zbyt niska wartość sprawi, że Laura będzie mówić bardziej mechanicznie, lecz będzie dokładniejsza pod względem faktycznym, natomiast zbyt wysoka wartość wygeneruje bardziej pomysłowy tekst, ale może powodować halucynacje – Laura mogłaby wymyślać informacje z powietrza.</system:String>
     <system:String x:Key="TOGGLE_FULLSCREEN_BORDER_FIX">Włącz/wyłącz poprawkę obramowania pełnego ekranu</system:String>
     <system:String x:Key="BORDER_FIX_ENABLED">Poprawka obramowania jest włączona.</system:String>
+    <system:String x:Key="GAMEPAD_SUPPORT">Obsługa gamepada</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher/Assets/Converters.axaml
+++ b/src/TombLauncher/Assets/Converters.axaml
@@ -61,5 +61,8 @@
         </valueConverters:StringNullToNullBitmapConverter>
         <valueConverters:CompatibilityToolToIconConverter x:Key="CompatibilityToolToIconConverter"/>
         <valueConverters:AiVendorToIconConverter x:Key="AiVendorToIconConverter"/>
+        
+        <!-- ── Booleans ── -->
+        <valueConverters:BooleanToBrushConverter x:Key="BooleanToBrushConverter" TrueValue="{StaticResource SuccessBrush}" FalseValue="{StaticResource WarningBrush}" />
     </Styles.Resources>
 </Styles>

--- a/src/TombLauncher/Extensions/ViewModelsServiceCollectionExtensions.cs
+++ b/src/TombLauncher/Extensions/ViewModelsServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ViewModelsServiceCollectionExtensions
             .AddTransient<WidescreenPatcherPageViewModel>()
             .AddTransient<TrxNativePatcherPageViewModel>()
             .AddTransient<WidescreenPatcherViewModel>()
-            .AddTransient<TrxNativePatcherViewModel>();
+            .AddTransient<TrxNativePatcherViewModel>()
+            .AddTransient<GamepadSupportMatrixViewModel>();
     }
 }

--- a/src/TombLauncher/ValueConverters/BooleanToBrushConverter.cs
+++ b/src/TombLauncher/ValueConverters/BooleanToBrushConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace TombLauncher.ValueConverters;
+
+public class BooleanToBrushConverter : IValueConverter
+{
+    public IBrush? TrueValue { get; set; }
+    public IBrush? FalseValue { get; set; }
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+        {
+            return b ? TrueValue : FalseValue;
+        }
+
+        return FalseValue;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/TombLauncher/ViewModels/MainWindowViewModel.cs
+++ b/src/TombLauncher/ViewModels/MainWindowViewModel.cs
@@ -8,7 +8,6 @@ using IconPacks.Avalonia.RemixIcon;
 using TombLauncher.Contracts.Navigation;
 using TombLauncher.Contracts.PlatformSpecific;
 using TombLauncher.Contracts.Settings;
-using TombLauncher.Core.PlatformSpecific;
 using TombLauncher.Localization.Extensions;
 using TombLauncher.Services;
 using TombLauncher.Utils;
@@ -58,6 +57,13 @@ public partial class MainWindowViewModel : WindowViewModelBase
                 Text = "STATISTICS".GetLocalizedString(),
                 ViewModelType = typeof(StatisticsPageViewModel)
             },
+            new MainMenuItemViewModel()
+            {
+                ToolTip = "GAMEPAD_SUPPORT".GetLocalizedString(),
+                Icon = PackIconRemixIconKind.GamepadLine,
+                Text = "GAMEPAD_SUPPORT".GetLocalizedString(),
+                ViewModelType = typeof(GamepadSupportMatrixViewModel)
+            }
         ];
 
         var aiEnabled = settingsProvider.GetAiCoreSettings().IsEnabled;

--- a/src/TombLauncher/ViewModels/Pages/GamepadSupportMatrixViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/GamepadSupportMatrixViewModel.cs
@@ -1,0 +1,20 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using TombLauncher.Contracts.Enums;
+using TombLauncher.Core.Extensions;
+using TombLauncher.Gamepad;
+using TombLauncher.Gamepad.SupportMatrix;
+
+namespace TombLauncher.ViewModels.Pages;
+
+public class GamepadSupportMatrixViewModel : PageViewModel
+{
+    public GamepadSupportMatrixViewModel(GamepadSupportMatrix gamepadSupportMatrix)
+    {
+        Entries = gamepadSupportMatrix.GetEntries()
+            .Where(e => e.Engine != GameEngine.Unknown)
+            .ToObservableCollection();
+    }
+
+    public ObservableCollection<GamepadSupportMatrixEntry> Entries { get; }
+}

--- a/src/TombLauncher/Views/Pages/GamepadSupportMatrixView.axaml
+++ b/src/TombLauncher/Views/Pages/GamepadSupportMatrixView.axaml
@@ -1,0 +1,52 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:pages="clr-namespace:TombLauncher.ViewModels.Pages"
+             xmlns:valueConverters="clr-namespace:TombLauncher.ValueConverters"
+             xmlns:localization="clr-namespace:TombLauncher.Localization;assembly=TombLauncher.Localization"
+             xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="TombLauncher.Views.Pages.GamepadSupportMatrixView"
+             x:DataType="pages:GamepadSupportMatrixViewModel">
+    <UserControl.Resources>
+        <valueConverters:BooleanToStringConverter x:Key="BooleanToStringConverter"
+                                                  TrueValue="GAMEPAD_NATIVE_SUPPORT"
+                                                  FalseValue="GAMEPAD_NO_NATIVE_SUPPORT" />
+        <valueConverters:BooleanToIconConverter x:Key="BooleanToIconConverter"
+                                                TrueValue="GamepadFill"
+                                                FalseValue="GamepadLine" />
+    </UserControl.Resources>
+    <ScrollViewer>
+        <StackPanel Orientation="Vertical" Spacing="16" Margin="8">
+            <TextBlock Classes="page-title"
+                       Text="{localization:Translate GAMEPAD_SUPPORT, Casing=Upper}" />
+
+            <ItemsControl ItemsSource="{Binding Entries}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Classes="card-background"
+                                CornerRadius="8"
+                                Padding="12 10"
+                                Margin="0 0 0 6"
+                                BorderBrush="{DynamicResource CardBorderBrush}"
+                                BorderThickness="1">
+                            <Grid ColumnDefinitions="Auto,*">
+                                <iconPacks:PackIconRemixIcon Margin="0, 0, 12, 0" Kind="{Binding HasNativeSupport, Converter={StaticResource BooleanToIconConverter}}"
+                                                             Width="28" Height="28"
+                                                             VerticalAlignment="Center"
+                                                             Foreground="{Binding HasNativeSupport, Converter={StaticResource BooleanToBrushConverter}}" />
+                                <StackPanel Grid.Column="1" Orientation="Vertical" VerticalAlignment="Center">
+                                    <TextBlock Text="{Binding Engine, Converter={StaticResource EnumToDescriptionConverter}}"
+                                               FontWeight="DemiBold" />
+                                    <TextBlock Text="{Binding HasNativeSupport, Converter={StaticResource BooleanToStringConverter}}"
+                                               Classes="text-muted" />
+                                </StackPanel>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/TombLauncher/Views/Pages/GamepadSupportMatrixView.axaml.cs
+++ b/src/TombLauncher/Views/Pages/GamepadSupportMatrixView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TombLauncher.Views.Pages;
+
+public partial class GamepadSupportMatrixView : UserControl
+{
+    public GamepadSupportMatrixView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/TombLauncher/Views/Pages/SettingsPageView.axaml
+++ b/src/TombLauncher/Views/Pages/SettingsPageView.axaml
@@ -48,5 +48,4 @@
                                  Command="{Binding SaveCommand}" />
         </DockPanel>
     </Grid>
-
 </UserControl>


### PR DESCRIPTION
Gamepad support matrix:
- New GamepadSupportMatrixEntry: DTO with Engine + HasNativeSupport
- New GamepadSupportMatrix.GetEntries(): projects the matrix dictionary to DTOs
- New GamepadSupportMatrixViewModel: populates entries, filters Unknown engine
- New GamepadSupportMatrixView: card-based list, icon color-coded (green = native, orange = requires AntiMicroX)
- New BooleanToBrushConverter: implemented and registered globally in Converters.axaml
- Sidebar: added "Gamepad support" entry in MainWindowViewModel
- DI: registered GamepadSupportMatrixViewModel as transient
- Localization: added GAMEPAD_SUPPORT to all 7 language files (GAMEPAD_NATIVE_SUPPORT / GAMEPAD_NO_NATIVE_SUPPORT were pre-existing)

Closes #181 