### PR TITLE
feat(savegame): extract and display BMP screenshots from TRNG savefiles

### DIFF
--- a/src/TombLauncher.Core/Savegames/TrngScreenshotExtractor.cs
+++ b/src/TombLauncher.Core/Savegames/TrngScreenshotExtractor.cs
@@ -1,0 +1,34 @@
+namespace TombLauncher.Core.Savegames;
+
+public static class TrngScreenshotExtractor
+{
+    private const int HeaderSize = 80;
+    private const int BmpHeaderSize = 14; // magic number (2 bytes), file size (4 bytes), reserved (4 bytes), offset (4 bytes)
+
+    public static byte[]? ExtractBitmap(byte[] data)
+    {
+        if (data.Length < HeaderSize + BmpHeaderSize)
+            return null;
+
+        for (var i = HeaderSize; i < data.Length - 1; i++)
+        {
+            if (data[i] == 'B' && data[i + 1] == 'M')
+            {
+                if (i + BmpHeaderSize > data.Length)
+                    return null;
+
+                var size = BitConverter.ToInt32(data, i + 2);
+
+                if (size < BmpHeaderSize || i + size > data.Length)
+                    return null;
+
+                var bmpData = new byte[size];
+                Array.Copy(data, i, bmpData, 0, size);
+
+                return bmpData;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/TombLauncher/Services/SavegameQueryService.cs
+++ b/src/TombLauncher/Services/SavegameQueryService.cs
@@ -4,13 +4,16 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Avalonia.Media.Imaging;
 using JamSoft.AvaloniaUI.Dialogs.MsgBox;
 using TombLauncher.Contracts.Enums;
 using TombLauncher.Core.Dtos;
 using TombLauncher.Core.Utils;
 using TombLauncher.Core.Extensions;
 using AvaloniaEdit.Utils;
+using Microsoft.Extensions.Logging;
 using TombLauncher.Contracts.Settings;
+using TombLauncher.Core.Savegames;
 using TombLauncher.Data.Database.Repositories;
 using TombLauncher.Extensions;
 using TombLauncher.Localization.Extensions;
@@ -24,17 +27,20 @@ public class SavegameQueryService
     private readonly ISavegameRepository _savegameRepository;
     private readonly ISavegameHeaderProvider _headerProvider;
     private readonly IPopupService _popupService;
+    private readonly ILogger<SavegameQueryService> _logger;
     private readonly int? _numberOfVersionsToKeep;
 
     public SavegameQueryService(
         ISavegameRepository savegameRepository,
         ISavegameHeaderProvider headerProvider,
         IPopupService popupService,
-        ISettingsProvider settingsProvider)
+        ISettingsProvider settingsProvider,
+        ILogger<SavegameQueryService> logger)
     {
         _savegameRepository = savegameRepository;
         _headerProvider = headerProvider;
         _popupService = popupService;
+        _logger = logger;
         _numberOfVersionsToKeep = settingsProvider.GetSavegameSettings().NumberOfVersionsToKeep;
     }
 
@@ -62,6 +68,22 @@ public class SavegameQueryService
                     Length = savegame.Data!.LongLength,
                     BackedUpOn = savegame.BackedUpOn
                 };
+
+                var bmp = TrngScreenshotExtractor.ExtractBitmap(savegame.Data);
+
+                if (bmp != null)
+                {
+                    try
+                    {
+                        using var memoryStream = new MemoryStream(bmp);
+                        viewModel.Screenshot = new Bitmap(memoryStream);
+                    }
+                    catch(Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Malformed BMP data found. Skip");
+                    }
+                }
+                
                 observableCollection.Add(viewModel);
             }
 

--- a/src/TombLauncher/ViewModels/SavegameViewModel.cs
+++ b/src/TombLauncher/ViewModels/SavegameViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows.Input;
+using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -7,14 +8,26 @@ namespace TombLauncher.ViewModels;
 
 public partial class SavegameViewModel : ViewModelBase
 {
-    [ObservableProperty] private int _id;
-    [ObservableProperty] private string _filename = string.Empty;
-    [ObservableProperty] private int _slotNumber;
-    [ObservableProperty] private int? _saveNumber;
-    [ObservableProperty] private string _levelName = string.Empty;
-    [ObservableProperty][NotifyCanExecuteChangedFor(nameof(DeleteSavegameCommand))] private bool _isStartOfLevel;
-    [ObservableProperty] private DateTime? _backedUpOn;
-    [ObservableProperty] private long _length;
+    [ObservableProperty]
+    public partial int Id { get; set; }
+    [ObservableProperty]
+    public partial string Filename { get; set; } = string.Empty;
+    [ObservableProperty]
+    public partial int SlotNumber { get; set; }
+    [ObservableProperty]
+    public partial int? SaveNumber { get; set; }
+    [ObservableProperty]
+    public partial string LevelName { get; set; } = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(DeleteSavegameCommand))]
+    public partial bool IsStartOfLevel { get; set; }
+    [ObservableProperty]
+    public partial DateTime? BackedUpOn { get; set; }
+    [ObservableProperty]
+    public partial long Length { get; set; }
+    
+    [ObservableProperty]
+    public partial Bitmap? Screenshot { get; set; }
     public ICommand? UpdateStartOfLevelStateCommand { get; set; }
     public IRelayCommand? DeleteSavegameCommand { get; set; }
     public ICommand? RestoreSavegameCommand { get; set; }

--- a/src/TombLauncher/Views/SavegameCardView.axaml
+++ b/src/TombLauncher/Views/SavegameCardView.axaml
@@ -48,6 +48,11 @@
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Row="0" Grid.Column="0">
+                <Image Source="{Binding Screenshot}"
+                       MaxHeight="160"
+                       Stretch="Uniform"
+                       Margin="0, 0, 0, 6"
+                       IsVisible="{Binding Screenshot, Converter={x:Static ObjectConverters.IsNotNull}}"></Image>
                 <controls:LabeledTextBlock Label="{loc:Translate SLOT_NUMBER}" 
                                            Text="{Binding SlotNumber}"/>
                 <TextBlock Classes="small" Text="{loc:Translate LEVEL_NAME}" />


### PR DESCRIPTION
- New TrngScreenshotExtractor: scans raw savefile bytes for BMP magic number after the 80-byte header, returns the BMP slice
- SavegameViewModel: added Screenshot property (Bitmap?)
- SavegameQueryService: calls extractor on load, converts BMP bytes to Avalonia Bitmap; malformed data logged and silently skipped
- SavegameCardView: added Image control (Stretch=Uniform) above metadata, visible only when Screenshot is non-null

Closes #146 