### PR TITLE
feat(resilience): add Polly resilience and response-time indicator for download sources (#173, #174)

### DIFF
--- a/src/TombLauncher.Contracts/Collections/CircularBuffer.cs
+++ b/src/TombLauncher.Contracts/Collections/CircularBuffer.cs
@@ -1,0 +1,6 @@
+namespace TombLauncher.Contracts.Collections;
+
+public class CircularBuffer
+{
+    
+}

--- a/src/TombLauncher.Contracts/Collections/CircularBuffer.cs
+++ b/src/TombLauncher.Contracts/Collections/CircularBuffer.cs
@@ -1,6 +1,0 @@
-namespace TombLauncher.Contracts.Collections;
-
-public class CircularBuffer
-{
-    
-}

--- a/src/TombLauncher.Contracts/Downloaders/SearchResultPage.cs
+++ b/src/TombLauncher.Contracts/Downloaders/SearchResultPage.cs
@@ -1,5 +1,15 @@
-using System.Collections.Generic;
-
 namespace TombLauncher.Contracts.Downloaders;
 
-public record SearchResultPage(IReadOnlyList<IGameSearchResultMetadata> Results, int? TotalPages) : ISearchResultPage;
+public record SearchResultPage : ISearchResultPage
+{
+    public SearchResultPage(IReadOnlyList<IGameSearchResultMetadata> results, int? totalPages)
+    {
+        Results = results;
+        TotalPages = totalPages;
+    }
+    
+    public IReadOnlyList<IGameSearchResultMetadata> Results { get; init; } = [];
+    public int? TotalPages { get; init; }
+
+    public static ISearchResultPage EmptyPage => new SearchResultPage([], 0);
+}

--- a/src/TombLauncher.Contracts/Enums/CircuitBreakerState.cs
+++ b/src/TombLauncher.Contracts/Enums/CircuitBreakerState.cs
@@ -1,0 +1,8 @@
+namespace TombLauncher.Contracts.Enums;
+
+public enum CircuitBreakerState
+{
+    Closed,
+    HalfOpen,
+    Open
+}

--- a/src/TombLauncher.Contracts/Enums/ServiceCheckStatus.cs
+++ b/src/TombLauncher.Contracts/Enums/ServiceCheckStatus.cs
@@ -5,5 +5,6 @@ public enum ServiceCheckStatus
     Unspecified,
     Checking,
     Okay,
-    Error
+    Error,
+    Warning
 }

--- a/src/TombLauncher.Contracts/TombLauncher.Contracts.csproj
+++ b/src/TombLauncher.Contracts/TombLauncher.Contracts.csproj
@@ -6,8 +6,4 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
-      <Folder Include="SupportMatrix\" />
-    </ItemGroup>
-
 </Project>

--- a/src/TombLauncher.Core/Collections/CircularBuffer.cs
+++ b/src/TombLauncher.Core/Collections/CircularBuffer.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TombLauncher.Core.Collections;
+
+public class CircularBuffer<T>
+{
+    private readonly T[] _buffer;
+    private readonly object _lock = new();
+    private int _head;
+    private int _count;
+
+    public CircularBuffer(int capacity) => _buffer = new T[capacity];
+
+    public T this[int index]
+    {
+        get
+        {
+            lock (_lock)
+                return _buffer[(_head - _count + index + _buffer.Length) % _buffer.Length];
+        }
+    }
+
+    public void Add(T item)
+    {
+        lock (_lock)
+        {
+            _buffer[_head] = item;
+            _head = (_head + 1) % _buffer.Length;
+            if (_count < _buffer.Length) _count++;
+        }
+    }
+
+    public IEnumerable<T> Items
+    {
+        get
+        {
+            lock (_lock)
+                return Enumerable.Range(0, _count)
+                    .Select(i => _buffer[(_head - _count + i + _buffer.Length) % _buffer.Length])
+                    .ToList();
+        }
+    }
+
+    public int Count
+    {
+        get { lock (_lock) return _count; }
+    }
+}

--- a/src/TombLauncher.Core/Extensions/CollectionsExtensions.cs
+++ b/src/TombLauncher.Core/Extensions/CollectionsExtensions.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using TombLauncher.Contracts;
-using TombLauncher.Core.Dtos;
 
 namespace TombLauncher.Core.Extensions;
 

--- a/src/TombLauncher.Localization/Localization/cs-CZ.axaml
+++ b/src/TombLauncher.Localization/Localization/cs-CZ.axaml
@@ -609,5 +609,7 @@
     <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Zatím není dostatek dat pro hodnocení stahovače {0}.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Jistič pro {0} je v napůl otevřeném stavu. Brzy bude možné akci zopakovat.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Stahovač {0} není dostupný. Akci bude možné zopakovat přibližně za minutu.</system:String>
+    <system:String x:Key="FAILED_TO_FETCH">Zdroj stahování je dočasně nedostupný</system:String>
+    <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Nepodařilo se dosáhnout {0} — automatický pokus bude proveden přibližně za minutu. Pokud problém přetrvává, zvažte deaktivaci tohoto zdroje v nastavení.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/cs-CZ.axaml
+++ b/src/TombLauncher.Localization/Localization/cs-CZ.axaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime">
     <!-- Miscellaneous -->
@@ -604,5 +604,10 @@
     <system:String x:Key="TOMB_2_MAIN_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TOMB_3_COMMUNITY_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TRX_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
+    <system:String x:Key="DOWNLOADER_PERFORMANCE_DEGRADED">Stahovač {0} vykazuje sníženou výkonnost. Odpověděl za {1}.</system:String>
+    <system:String x:Key="DOWNLOADER_RESPONDED_IN_MS">Stahovač {0} odpověděl za {1} ms. Vše je v pořádku.</system:String>
+    <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Zatím není dostatek dat pro hodnocení stahovače {0}.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Jistič pro {0} je v napůl otevřeném stavu. Brzy bude možné akci zopakovat.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_OPEN">Stahovač {0} není dostupný. Akci bude možné zopakovat přibližně za minutu.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/de-DE.axaml
+++ b/src/TombLauncher.Localization/Localization/de-DE.axaml
@@ -609,5 +609,7 @@
     <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Noch nicht genügend Daten, um den Downloader {0} zu bewerten.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Der Circuit Breaker für {0} ist halb offen. Er wird in Kürze wieder verfügbar sein.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Der Downloader {0} ist nicht erreichbar. Er wird in etwa einer Minute wieder verfügbar sein.</system:String>
+    <system:String x:Key="FAILED_TO_FETCH">Eine Download-Quelle ist vorübergehend nicht verfügbar</system:String>
+    <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">{0} ist nicht erreichbar — es wird in etwa einer Minute automatisch erneut versucht. Wenn das Problem weiterhin besteht, erwägen Sie, die Quelle in den Einstellungen zu deaktivieren.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/de-DE.axaml
+++ b/src/TombLauncher.Localization/Localization/de-DE.axaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime">
     <!-- Miscellaneous -->
@@ -604,5 +604,10 @@
     <system:String x:Key="TOMB_2_MAIN_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TOMB_3_COMMUNITY_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TRX_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
+    <system:String x:Key="DOWNLOADER_PERFORMANCE_DEGRADED">Der Downloader {0} zeigt eine verminderte Leistung. Er hat in {1} geantwortet.</system:String>
+    <system:String x:Key="DOWNLOADER_RESPONDED_IN_MS">Der Downloader {0} hat in {1} ms geantwortet. Alles in Ordnung.</system:String>
+    <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Noch nicht genügend Daten, um den Downloader {0} zu bewerten.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Der Circuit Breaker für {0} ist halb offen. Er wird in Kürze wieder verfügbar sein.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_OPEN">Der Downloader {0} ist nicht erreichbar. Er wird in etwa einer Minute wieder verfügbar sein.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -612,5 +612,10 @@
     <system:String x:Key="TOMB_2_MAIN_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TOMB_3_COMMUNITY_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TRX_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
+    <system:String x:Key="DOWNLOADER_PERFORMANCE_DEGRADED">Downloader {0} is showing degraded performance. It responded in {1}.</system:String>
+    <system:String x:Key="DOWNLOADER_RESPONDED_IN_MS">Downloader {0} responded in {1} ms. Everything is fine.</system:String>
+    <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Not enough data yet to evaluate downloader {0}.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">The circuit breaker for {0} is half-open. It will be available to retry shortly.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_OPEN">Downloader {0} is unreachable. It will be available to retry in about a minute.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="using:TombLauncher.Localization"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime">
@@ -617,5 +617,7 @@
     <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Not enough data yet to evaluate downloader {0}.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">The circuit breaker for {0} is half-open. It will be available to retry shortly.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Downloader {0} is unreachable. It will be available to retry in about a minute.</system:String>
+    <system:String x:Key="FAILED_TO_FETCH">A download source is temporarily unavailable</system:String>
+    <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Could not reach {0} — it will be retried automatically in about a minute. If it keeps failing, consider disabling it in the settings.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/es-ES.axaml
+++ b/src/TombLauncher.Localization/Localization/es-ES.axaml
@@ -609,5 +609,7 @@
     <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Aún no hay suficientes datos para evaluar el descargador {0}.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">El circuit breaker de {0} está en estado semiabierto. Estará disponible para reintentar en breve.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">El descargador {0} no es accesible. Estará disponible para reintentar en aproximadamente un minuto.</system:String>
+    <system:String x:Key="FAILED_TO_FETCH">Una fuente de descarga no está disponible temporalmente</system:String>
+    <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">No se pudo contactar con {0} — se reintentará automáticamente en aproximadamente un minuto. Si el problema persiste, considera desactivarla en la configuración.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/es-ES.axaml
+++ b/src/TombLauncher.Localization/Localization/es-ES.axaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime">
     <!-- Miscellaneous -->
@@ -604,5 +604,10 @@
     <system:String x:Key="TOMB_2_MAIN_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TOMB_3_COMMUNITY_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TRX_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
+    <system:String x:Key="DOWNLOADER_PERFORMANCE_DEGRADED">El descargador {0} muestra un rendimiento degradado. Ha respondido en {1}.</system:String>
+    <system:String x:Key="DOWNLOADER_RESPONDED_IN_MS">El descargador {0} ha respondido en {1} ms. Todo está en orden.</system:String>
+    <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Aún no hay suficientes datos para evaluar el descargador {0}.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">El circuit breaker de {0} está en estado semiabierto. Estará disponible para reintentar en breve.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_OPEN">El descargador {0} no es accesible. Estará disponible para reintentar en aproximadamente un minuto.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/fr-FR.axaml
+++ b/src/TombLauncher.Localization/Localization/fr-FR.axaml
@@ -609,5 +609,7 @@
     <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Pas encore assez de données pour évaluer le téléchargeur {0}.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Le circuit breaker de {0} est en état semi-ouvert. Il sera disponible pour une nouvelle tentative sous peu.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Le téléchargeur {0} est inaccessible. Il sera disponible pour une nouvelle tentative dans environ une minute.</system:String>
+    <system:String x:Key="FAILED_TO_FETCH">Une source de téléchargement est temporairement indisponible</system:String>
+    <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Impossible d'atteindre {0} — une nouvelle tentative sera effectuée automatiquement dans environ une minute. Si le problème persiste, envisagez de la désactiver dans les paramètres.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/fr-FR.axaml
+++ b/src/TombLauncher.Localization/Localization/fr-FR.axaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime">
     <!-- Miscellaneous -->
@@ -604,5 +604,10 @@
     <system:String x:Key="TOMB_2_MAIN_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TOMB_3_COMMUNITY_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TRX_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
+    <system:String x:Key="DOWNLOADER_PERFORMANCE_DEGRADED">Le téléchargeur {0} montre des performances dégradées. Il a répondu en {1}.</system:String>
+    <system:String x:Key="DOWNLOADER_RESPONDED_IN_MS">Le téléchargeur {0} a répondu en {1} ms. Tout est en ordre.</system:String>
+    <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Pas encore assez de données pour évaluer le téléchargeur {0}.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Le circuit breaker de {0} est en état semi-ouvert. Il sera disponible pour une nouvelle tentative sous peu.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_OPEN">Le téléchargeur {0} est inaccessible. Il sera disponible pour une nouvelle tentative dans environ une minute.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -611,5 +611,10 @@
     <system:String x:Key="TOMB_3_COMMUNITY_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS non è attualmente supportato da Tomb Launcher.</system:String>
     <system:String x:Key="TRX_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS non è attualmente supportato da Tomb Launcher.</system:String>
     <system:String x:Key="ENGINE_SUPPORT">Engine supportati</system:String>
+    <system:String x:Key="DOWNLOADER_PERFORMANCE_DEGRADED">Il downloader {0} mostra performance degradate. Ha risposto in {1}.</system:String>
+    <system:String x:Key="DOWNLOADER_RESPONDED_IN_MS">Il downloader {0} ha risposto in {1} ms. È tutto in ordine.</system:String>
+    <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Non sono ancora presenti dati a sufficienza per valutare il downloader {0}.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Il meccanismo di circuit breaker di {0} è in stato semi-aperto. Sarà possibile ritentarne l'utilizzo a breve.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_OPEN">Il downloader {0} non è raggiungibile. Sarà possibile ritentarne l'utilizzo tra circa un minuto.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime">
     <!-- Miscellaneous -->
@@ -616,5 +616,7 @@
     <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Non sono ancora presenti dati a sufficienza per valutare il downloader {0}.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Il meccanismo di circuit breaker di {0} è in stato semi-aperto. Sarà possibile ritentarne l'utilizzo a breve.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Il downloader {0} non è raggiungibile. Sarà possibile ritentarne l'utilizzo tra circa un minuto.</system:String>
+    <system:String x:Key="FAILED_TO_FETCH">Una sorgente di download è temporaneamente non disponibile</system:String>
+    <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Impossibile raggiungere {0} — verrà ritentato automaticamente tra circa un minuto. Se il problema persiste, valuta di disabilitarla nelle impostazioni.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/pl-PL.axaml
+++ b/src/TombLauncher.Localization/Localization/pl-PL.axaml
@@ -609,5 +609,7 @@
     <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Brak wystarczających danych do oceny downloadera {0}.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Circuit breaker dla {0} jest w stanie półotwartym. Wkrótce będzie można ponowić próbę.</system:String>
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Downloader {0} jest niedostępny. Ponowienie próby będzie możliwe za około minutę.</system:String>
+    <system:String x:Key="FAILED_TO_FETCH">Źródło pobierania jest tymczasowo niedostępne</system:String>
+    <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Nie można połączyć się z {0} — próba zostanie ponowiona automatycznie za około minutę. Jeśli problem się utrzymuje, rozważ wyłączenie tego źródła w ustawieniach.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/pl-PL.axaml
+++ b/src/TombLauncher.Localization/Localization/pl-PL.axaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime">
     <!-- Miscellaneous -->
@@ -604,5 +604,10 @@
     <system:String x:Key="TOMB_2_MAIN_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TOMB_3_COMMUNITY_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
     <system:String x:Key="TRX_MACOS_SUPPORT_SHORT_DESCRIPTION">macOS is not currently supported by Tomb Launcher.</system:String>
+    <system:String x:Key="DOWNLOADER_PERFORMANCE_DEGRADED">Downloader {0} wykazuje spadek wydajności. Odpowiedź nastąpiła w ciągu {1}.</system:String>
+    <system:String x:Key="DOWNLOADER_RESPONDED_IN_MS">Downloader {0} odpowiedział w {1} ms. Wszystko jest w porządku.</system:String>
+    <system:String x:Key="NOT_ENOUGH_DATA_FOR_DOWNLOADER">Brak wystarczających danych do oceny downloadera {0}.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_HALF_OPEN">Circuit breaker dla {0} jest w stanie półotwartym. Wkrótce będzie można ponowić próbę.</system:String>
+    <system:String x:Key="CIRCUIT_BREAKER_OPEN">Downloader {0} jest niedostępny. Ponowienie próby będzie możliwe za około minutę.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher/Extensions/DownloaderServiceCollectionExtensions.cs
+++ b/src/TombLauncher/Extensions/DownloaderServiceCollectionExtensions.cs
@@ -115,7 +115,8 @@ public static class DownloaderServiceCollectionExtensions
             .AddTransient<IGameDownloader, RaidingTheGlobeGameDownloader>()
             .AddTransient(sp =>
             {
-                var downloadManager = new GameDownloadManager(sp.GetRequiredService<IGameMerger>())
+                var downloadManager = new GameDownloadManager(sp.GetRequiredService<IGameMerger>(),
+                    sp.GetRequiredService<ILogger<GameDownloadManager>>())
                 {
                     Downloaders = sp.GetRequiredService<ISettingsProvider>().GetActiveDownloaders()
                 };

--- a/src/TombLauncher/Extensions/DownloaderServiceCollectionExtensions.cs
+++ b/src/TombLauncher/Extensions/DownloaderServiceCollectionExtensions.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using Octokit;
+using Polly;
 using TombLauncher.Contracts.Downloaders;
 using TombLauncher.Contracts.Localization;
 using TombLauncher.Contracts.Settings;
@@ -15,19 +17,59 @@ using TombLauncher.Installers.Downloaders.AspideTR.com;
 using TombLauncher.Installers.Downloaders.RaidingTheGlobe.com;
 using TombLauncher.Installers.Downloaders.TRCustoms.org;
 using TombLauncher.Installers.Downloaders.TRLE.net;
+using TombLauncher.Installers.Resilience;
 using TombLauncher.Services;
 
 namespace TombLauncher.Extensions;
 
 public static class DownloaderServiceCollectionExtensions
 {
+    private const int PerAttemptTimeoutSeconds = 15;
+    private const int RetryAttempts = 3;
+    private const double RetryBaseDelaySeconds = 2.0;
+    private const int CircuitBreakerMinThroughput = 5;
+    private const double CircuitBreakerFailureRatio = 0.5;
+    private const int CircuitBreakerSamplingSeconds = 30;
+    private const int CircuitBreakerBreakSeconds = 60;
+
+    private static IServiceCollection AddDownloaderInfrastructure<T>(this IServiceCollection services,
+        Action<HttpClient> configureClient)
+    {
+        var downloaderName = typeof(T).Name;
+
+        services.AddHttpClient(downloaderName, configureClient)
+            .AddHttpMessageHandler(sp => new ResponseTimeMeasurementHandler(downloaderName,
+                sp.GetRequiredService<IDownloaderResponseTimeService>()))
+            .AddResilienceHandler(downloaderName, builder =>
+            {
+                builder.AddTimeout(TimeSpan.FromSeconds(PerAttemptTimeoutSeconds));
+                builder.AddRetry(new HttpRetryStrategyOptions()
+                {
+                    MaxRetryAttempts = RetryAttempts,
+                    BackoffType = DelayBackoffType.Exponential,
+                    Delay = TimeSpan.FromSeconds(RetryBaseDelaySeconds),
+                    UseJitter = true
+                });
+
+                builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions()
+                {
+                    MinimumThroughput = CircuitBreakerMinThroughput,
+                    FailureRatio = CircuitBreakerFailureRatio,
+                    SamplingDuration = TimeSpan.FromSeconds(CircuitBreakerSamplingSeconds),
+                    BreakDuration = TimeSpan.FromSeconds(CircuitBreakerBreakSeconds)
+                });
+            });
+
+        return services;
+    }
+
     public static IServiceCollection AddDownloaders(this IServiceCollection services)
     {
         var appVersion = VersionUtils.GetApplicationVersion();
         var versionString = appVersion is null ? "0.0.0" : $"{appVersion.Major}.{appVersion.Minor}.{appVersion.Build}";
         services.AddSingleton(new GitHubClient(new Octokit.ProductHeaderValue("TombLauncher", versionString)))
             .AddTransient<GitHubReleaseService>()
-            .AddHttpClient(nameof(TrleGameDownloader), c =>
+            .AddDownloaderInfrastructure<TrleGameDownloader>(c =>
             {
                 c.BaseAddress = new Uri("https://trle.net");
                 c.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
@@ -36,27 +78,29 @@ public static class DownloaderServiceCollectionExtensions
                 c.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("image/avif"));
                 c.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("image/webp"));
                 c.DefaultRequestHeaders.Referrer = new Uri("https://trle.net/pFind.php");
-            });
-        services.AddHttpClient(nameof(AspideTrGameDownloader),
-            c => { c.BaseAddress = new Uri("https://www.aspidetr.com/"); });
-        services.AddHttpClient(nameof(TrCustomsGameDownloader), c =>
-        {
-            c.BaseAddress = new Uri("https://trcustoms.org/");
-            c.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        });
-        services.AddHttpClient(nameof(RaidingTheGlobeGameDownloader),
-            c => { c.BaseAddress = new Uri("https://www.raidingtheglobe.com"); });
-
-        services.AddTransient<TrleGameDownloader>()
+            })
+            .AddDownloaderInfrastructure<AspideTrGameDownloader>(c =>
+            {
+                c.BaseAddress = new Uri("https://www.aspidetr.com/");
+            })
+            .AddDownloaderInfrastructure<TrCustomsGameDownloader>(c =>
+            {
+                c.BaseAddress = new Uri("https://trcustoms.org/");
+                c.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            })
+            .AddDownloaderInfrastructure<RaidingTheGlobeGameDownloader>(c =>
+            {
+                c.BaseAddress = new Uri("https://www.raidingtheglobe.com");
+            })
+            .AddTransient<TrleGameDownloader>()
             .AddTransient(sp => new AspideTrGameDownloader(
                 sp.GetRequiredService<IHttpClientFactory>(),
                 sp.GetRequiredService<ILocalizationManager>().GetSubsetInvertedByPrefix("ATR"),
                 sp.GetRequiredService<ILogger<AspideTrGameDownloader>>()))
             .AddTransient<TrCustomsGameDownloader>()
-            .AddTransient<RaidingTheGlobeGameDownloader>();
-
-        // Registrazione come IGameDownloader per GetServices<IGameDownloader>()
-        services.AddTransient<IGameDownloader, TrleGameDownloader>()
+            .AddTransient<RaidingTheGlobeGameDownloader>()
+            // Registrazione come IGameDownloader per GetServices<IGameDownloader>()
+            .AddTransient<IGameDownloader, TrleGameDownloader>()
             .AddTransient<IGameDownloader>(sp => new AspideTrGameDownloader(
                 sp.GetRequiredService<IHttpClientFactory>(),
                 sp.GetRequiredService<ILocalizationManager>().GetSubsetInvertedByPrefix("ATR"),
@@ -80,7 +124,8 @@ public static class DownloaderServiceCollectionExtensions
                 ".sfx",
                 ".dat",
                 ".phd"
-            }));
+            }))
+            .AddSingleton<IDownloaderResponseTimeService, DownloaderResponseTimeService>();
         return services;
     }
 }

--- a/src/TombLauncher/Extensions/DownloaderServiceCollectionExtensions.cs
+++ b/src/TombLauncher/Extensions/DownloaderServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Octokit;
 using Polly;
 using TombLauncher.Contracts.Downloaders;
+using TombLauncher.Contracts.Enums;
 using TombLauncher.Contracts.Localization;
 using TombLauncher.Contracts.Settings;
 using TombLauncher.Core.Utils;
@@ -40,15 +41,17 @@ public static class DownloaderServiceCollectionExtensions
         services.AddHttpClient(downloaderName, configureClient)
             .AddHttpMessageHandler(sp => new ResponseTimeMeasurementHandler(downloaderName,
                 sp.GetRequiredService<IDownloaderResponseTimeService>()))
-            .AddResilienceHandler(downloaderName, builder =>
+            .AddResilienceHandler(downloaderName, (builder, context) =>
             {
+                var responseTimeService = context.ServiceProvider.GetRequiredService<IDownloaderResponseTimeService>();
+                
                 builder.AddTimeout(TimeSpan.FromSeconds(PerAttemptTimeoutSeconds));
                 builder.AddRetry(new HttpRetryStrategyOptions()
                 {
                     MaxRetryAttempts = RetryAttempts,
                     BackoffType = DelayBackoffType.Exponential,
                     Delay = TimeSpan.FromSeconds(RetryBaseDelaySeconds),
-                    UseJitter = true
+                    UseJitter = true,
                 });
 
                 builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions()
@@ -56,7 +59,10 @@ public static class DownloaderServiceCollectionExtensions
                     MinimumThroughput = CircuitBreakerMinThroughput,
                     FailureRatio = CircuitBreakerFailureRatio,
                     SamplingDuration = TimeSpan.FromSeconds(CircuitBreakerSamplingSeconds),
-                    BreakDuration = TimeSpan.FromSeconds(CircuitBreakerBreakSeconds)
+                    BreakDuration = TimeSpan.FromSeconds(CircuitBreakerBreakSeconds),
+                    OnOpened = _ => responseTimeService.SetCircuitBreakerStatus(downloaderName, CircuitBreakerState.Open),
+                    OnHalfOpened = _ => responseTimeService.SetCircuitBreakerStatus(downloaderName, CircuitBreakerState.HalfOpen),
+                    OnClosed = _ => responseTimeService.SetCircuitBreakerStatus(downloaderName, CircuitBreakerState.Closed)
                 });
             });
 

--- a/src/TombLauncher/Installers/Downloaders/AspideTR.com/AspideTrGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/AspideTR.com/AspideTrGameDownloader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -162,8 +163,9 @@ public class AspideTrGameDownloader : GameDownloaderBase
         var urlEncodedContent = new FormUrlEncodedContent(kvpList);
         var queryString = await urlEncodedContent.ReadAsStringAsync(cancellationToken);
         var url = GetPageUrl(pageNumber, queryString);
+        var pageContent = await HttpClient.GetStringAsync(url, cancellationToken);
 
-        var htmlDocument = await AppUtils.OpenDocument(url, cancellationToken);
+        var htmlDocument = await AppUtils.OpenDocumentFromContent(pageContent, cancellationToken);
         var totalPages = GetTotalPages(htmlDocument);
 
         await ParsePage(htmlDocument, result);
@@ -193,7 +195,8 @@ public class AspideTrGameDownloader : GameDownloaderBase
         CancellationToken cancellationToken)
     {
         var detailsLink = new Uri(new Uri(BaseUrl), game.DetailsLink).ToString();
-        var htmlDocument = await AppUtils.OpenDocument(detailsLink, cancellationToken);
+        var detailsPage = await HttpClient.GetStringAsync(detailsLink, cancellationToken);
+        var htmlDocument = await AppUtils.OpenDocumentFromContent(detailsPage, cancellationToken);
         var dto = new GameMetadataDto()
         {
             Author = game.Author,

--- a/src/TombLauncher/Installers/Downloaders/AspideTR.com/AspideTrGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/AspideTR.com/AspideTrGameDownloader.cs
@@ -163,7 +163,15 @@ public class AspideTrGameDownloader : GameDownloaderBase
         var urlEncodedContent = new FormUrlEncodedContent(kvpList);
         var queryString = await urlEncodedContent.ReadAsStringAsync(cancellationToken);
         var url = GetPageUrl(pageNumber, queryString);
-        var pageContent = await HttpClient.GetStringAsync(url, cancellationToken);
+        string? pageContent;
+        try
+        {
+            pageContent = await HttpClient.GetStringAsync(url, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return SearchResultPage.EmptyPage;
+        }
 
         var htmlDocument = await AppUtils.OpenDocumentFromContent(pageContent, cancellationToken);
         var totalPages = GetTotalPages(htmlDocument);

--- a/src/TombLauncher/Installers/Downloaders/GameDownloadManager.cs
+++ b/src/TombLauncher/Installers/Downloaders/GameDownloadManager.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Polly.CircuitBreaker;
 using TombLauncher.Contracts.Downloaders;
 using TombLauncher.Contracts.Progress;
 using TombLauncher.Core.Dtos;
@@ -13,37 +16,54 @@ namespace TombLauncher.Installers.Downloaders;
 
 public class GameDownloadManager
 {
-    public GameDownloadManager(IGameMerger merger)
+    public GameDownloadManager(IGameMerger merger, ILogger<GameDownloadManager> logger)
     {
         _merger = merger;
+        _logger = logger;
         Downloaders = [];
     }
 
     public List<IGameDownloader> Downloaders { get; init; }
     private CancellationTokenSource _cancellationTokenSource = new();
     private readonly IGameMerger _merger;
+    private readonly ILogger<GameDownloadManager> _logger;
 
-    public async Task<(List<IMergedGameSearchResultMetadata> Results, int? MaxTotalPages)> GetGames(
+    public async Task<(List<IMergedGameSearchResultMetadata> Results, int? MaxTotalPages, ConcurrentBag<string> FailedDownloaders)> GetGames(
         IReadOnlyList<IGameDownloader> downloaders,
         DownloaderSearchPayload searchPayload, int page)
     {
+        var failedDownloaders = new ConcurrentBag<string>();
         var outputList = new List<IMergedGameSearchResultMetadata>();
         var tasks = downloaders
-            .Select(d => d.Search.GetGames(searchPayload, page, _cancellationTokenSource.Token))
+            .Select(async d =>
+            {
+                ISearchResultPage? result = null;
+                try
+                {
+                    result = await d.Search.GetGames(searchPayload, page, _cancellationTokenSource.Token);
+                }
+                catch (BrokenCircuitException ex)
+                {
+                    failedDownloaders.Add(d.DisplayName);
+                    _logger.LogInformation(ex, "Circuit breaker was open");
+                }
+
+                return result;
+            })
             .ToList();
 
         await Task.WhenAll(tasks);
 
         var maxTotalPages = 0;
-        foreach (var completedTask in tasks.Where(t => t.IsCompleted))
+        foreach (var completedTask in tasks.Where(t => t.Result != null))
         {
-            var resultPage = completedTask.Result;
+            var resultPage = completedTask.Result!;
             _merger.Merge(outputList, resultPage.Results.ToList());
             if (resultPage.TotalPages.HasValue && resultPage.TotalPages.Value > maxTotalPages)
                 maxTotalPages = resultPage.TotalPages.Value;
         }
 
-        return (outputList, maxTotalPages > 0 ? maxTotalPages : null);
+        return (outputList, maxTotalPages > 0 ? maxTotalPages : null, failedDownloaders);
     }
 
     public async Task<IGameMetadata?> FetchDetails(IGameSearchResultMetadata game)

--- a/src/TombLauncher/Installers/Downloaders/RaidingTheGlobe.com/RaidingTheGlobeGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/RaidingTheGlobe.com/RaidingTheGlobeGameDownloader.cs
@@ -34,7 +34,9 @@ public class RaidingTheGlobeGameDownloader : GameDownloaderBase
         var uriBuilder = new UriBuilder(new Uri(BaseUrl));
         uriBuilder.Path = "/downloads/custom-games-tomb-raider-level-editor";
 
-        var htmlDocument = await AppUtils.OpenDocument(uriBuilder.Uri.ToString(), cancellationToken);
+        var page = await HttpClient.GetStringAsync(uriBuilder.Uri, cancellationToken);
+
+        var htmlDocument = await AppUtils.OpenDocumentFromContent(page, cancellationToken);
 
         var allLevels = new List<IGameSearchResultMetadata>();
 

--- a/src/TombLauncher/Installers/Downloaders/TRLE.net/TrleGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/TRLE.net/TrleGameDownloader.cs
@@ -195,7 +195,8 @@ public class TrleGameDownloader : GameDownloaderBase
         CancellationToken cancellationToken)
     {
         var detailsUrl = new Uri(new Uri(BaseUrl), game.DetailsLink).ToString();
-        var htmlDocument = await AppUtils.OpenDocument(detailsUrl, cancellationToken);
+        var detailsPage = await HttpClient.GetStringAsync(detailsUrl, cancellationToken);
+        var htmlDocument = await AppUtils.OpenDocumentFromContent(detailsPage, cancellationToken);
         var metadata = new GameMetadataDto
         {
             Author = game.Author,

--- a/src/TombLauncher/Installers/Resilience/DownloaderResponseTimeService.cs
+++ b/src/TombLauncher/Installers/Resilience/DownloaderResponseTimeService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace TombLauncher.Installers.Resilience;
+
+public class DownloaderResponseTimeService : IDownloaderResponseTimeService
+{
+    private readonly ConcurrentDictionary<string, TimeSpan> _recordings = new();
+    public void RecordResponseTime(string clientName, TimeSpan elapsed)
+    {
+        _recordings[clientName] = elapsed;
+    }
+
+    public TimeSpan? GetLastResponseTime(string clientName)
+    {
+        if (_recordings.TryGetValue(clientName, out var responseTime))
+            return responseTime;
+
+        return null;
+    }
+}

--- a/src/TombLauncher/Installers/Resilience/DownloaderResponseTimeService.cs
+++ b/src/TombLauncher/Installers/Resilience/DownloaderResponseTimeService.cs
@@ -1,14 +1,19 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TombLauncher.Contracts.Enums;
 
 namespace TombLauncher.Installers.Resilience;
 
 public class DownloaderResponseTimeService : IDownloaderResponseTimeService
 {
     private readonly ConcurrentDictionary<string, TimeSpan> _recordings = new();
+    private readonly ConcurrentDictionary<string, CircuitBreakerState> _circuitBreakerStates = new();
     public void RecordResponseTime(string clientName, TimeSpan elapsed)
     {
         _recordings[clientName] = elapsed;
+        OnMeasureUpdated?.Invoke(clientName, _circuitBreakerStates.GetValueOrDefault(clientName, CircuitBreakerState.Closed));
     }
 
     public TimeSpan? GetLastResponseTime(string clientName)
@@ -18,4 +23,13 @@ public class DownloaderResponseTimeService : IDownloaderResponseTimeService
 
         return null;
     }
+
+    public ValueTask SetCircuitBreakerStatus(string clientName, CircuitBreakerState state)
+    {
+        _circuitBreakerStates[clientName] = state;
+        OnMeasureUpdated?.Invoke(clientName, state);
+        return ValueTask.CompletedTask;
+    }
+
+    public event Action<string, CircuitBreakerState>? OnMeasureUpdated;
 }

--- a/src/TombLauncher/Installers/Resilience/DownloaderResponseTimeService.cs
+++ b/src/TombLauncher/Installers/Resilience/DownloaderResponseTimeService.cs
@@ -1,25 +1,28 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using TombLauncher.Core.Collections;
 using TombLauncher.Contracts.Enums;
 
 namespace TombLauncher.Installers.Resilience;
 
 public class DownloaderResponseTimeService : IDownloaderResponseTimeService
 {
-    private readonly ConcurrentDictionary<string, TimeSpan> _recordings = new();
+    private const int ElementsToSave = 10;
+    private readonly ConcurrentDictionary<string, CircularBuffer<TimeSpan>> _recordings = new();
     private readonly ConcurrentDictionary<string, CircuitBreakerState> _circuitBreakerStates = new();
     public void RecordResponseTime(string clientName, TimeSpan elapsed)
     {
-        _recordings[clientName] = elapsed;
+        _recordings.GetOrAdd(clientName, _ => new CircularBuffer<TimeSpan>(ElementsToSave)).Add(elapsed);
         OnMeasureUpdated?.Invoke(clientName, _circuitBreakerStates.GetValueOrDefault(clientName, CircuitBreakerState.Closed));
     }
 
-    public TimeSpan? GetLastResponseTime(string clientName)
+    public TimeSpan? GetAverageResponseTime(string clientName)
     {
-        if (_recordings.TryGetValue(clientName, out var responseTime))
-            return responseTime;
+        if (_recordings.TryGetValue(clientName, out var responseTimes))
+            return TimeSpan.FromMilliseconds(responseTimes.Items.Sum(i => i.TotalMilliseconds) / responseTimes.Count);
 
         return null;
     }

--- a/src/TombLauncher/Installers/Resilience/IDownloaderResponseTimeService.cs
+++ b/src/TombLauncher/Installers/Resilience/IDownloaderResponseTimeService.cs
@@ -7,7 +7,7 @@ namespace TombLauncher.Installers.Resilience;
 public interface IDownloaderResponseTimeService
 {
     void RecordResponseTime(string clientName, TimeSpan elapsed);
-    TimeSpan? GetLastResponseTime(string clientName);
+    TimeSpan? GetAverageResponseTime(string clientName);
 
     ValueTask SetCircuitBreakerStatus(string clientName, CircuitBreakerState state);
 

--- a/src/TombLauncher/Installers/Resilience/IDownloaderResponseTimeService.cs
+++ b/src/TombLauncher/Installers/Resilience/IDownloaderResponseTimeService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading.Tasks;
+using TombLauncher.Contracts.Enums;
 
 namespace TombLauncher.Installers.Resilience;
 
@@ -6,4 +8,8 @@ public interface IDownloaderResponseTimeService
 {
     void RecordResponseTime(string clientName, TimeSpan elapsed);
     TimeSpan? GetLastResponseTime(string clientName);
+
+    ValueTask SetCircuitBreakerStatus(string clientName, CircuitBreakerState state);
+
+    event Action<string, CircuitBreakerState> OnMeasureUpdated;
 }

--- a/src/TombLauncher/Installers/Resilience/IDownloaderResponseTimeService.cs
+++ b/src/TombLauncher/Installers/Resilience/IDownloaderResponseTimeService.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace TombLauncher.Installers.Resilience;
+
+public interface IDownloaderResponseTimeService
+{
+    void RecordResponseTime(string clientName, TimeSpan elapsed);
+    TimeSpan? GetLastResponseTime(string clientName);
+}

--- a/src/TombLauncher/Installers/Resilience/ResponseTimeMeasurementHandler.cs
+++ b/src/TombLauncher/Installers/Resilience/ResponseTimeMeasurementHandler.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TombLauncher.Installers.Resilience;
+
+public class ResponseTimeMeasurementHandler : DelegatingHandler
+{
+    private readonly IDownloaderResponseTimeService _downloaderResponseTimeService;
+    private readonly string _clientName;
+
+    public ResponseTimeMeasurementHandler(string clientName, IDownloaderResponseTimeService downloaderResponseTimeService)
+    {
+        _clientName = clientName;
+        _downloaderResponseTimeService = downloaderResponseTimeService;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var stopWatch = Stopwatch.StartNew();
+        var response = await base.SendAsync(request, cancellationToken);
+        stopWatch.Stop();
+        if (response.IsSuccessStatusCode)
+            _downloaderResponseTimeService.RecordResponseTime(_clientName, stopWatch.Elapsed);
+        return response;
+    }
+}

--- a/src/TombLauncher/Mappers/SettingsMapper.cs
+++ b/src/TombLauncher/Mappers/SettingsMapper.cs
@@ -3,8 +3,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using TombLauncher.Contracts.Localization.Dtos;
 using TombLauncher.Contracts.Settings;
-using TombLauncher.Core.Dtos;
 using TombLauncher.Core.Extensions;
+using TombLauncher.Installers.Resilience;
 using TombLauncher.ViewModels;
 using TombLauncher.ViewModels.Pages.Settings;
 
@@ -12,6 +12,13 @@ namespace TombLauncher.Mappers;
 
 public class SettingsMapper
 {
+    private readonly IDownloaderResponseTimeService _downloaderResponseTimeService;
+
+    public SettingsMapper(IDownloaderResponseTimeService downloaderResponseTimeService)
+    {
+        _downloaderResponseTimeService = downloaderResponseTimeService;
+    }
+    
     public ApplicationLanguageViewModel ToViewModel(AvailableLanguageDto dto)
     {
         return new ApplicationLanguageViewModel()
@@ -56,7 +63,7 @@ public class SettingsMapper
 
     public DownloaderViewModel ToViewModel(DownloaderConfiguration dto)
     {
-        return new DownloaderViewModel()
+        return new DownloaderViewModel(_downloaderResponseTimeService)
         {
             DisplayName = dto.DisplayName,
             BaseUrl = dto.BaseUrl,

--- a/src/TombLauncher/Services/GameSearchService.cs
+++ b/src/TombLauncher/Services/GameSearchService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using AvaloniaEdit.Utils;
+using IconPacks.Avalonia.RemixIcon;
 using Microsoft.Extensions.Logging;
 using TombLauncher.Contracts.Downloaders;
 using TombLauncher.Contracts.Enums;
@@ -74,8 +75,15 @@ public class GameSearchService : IViewService
         using (target.BusyScope("LOADING_IN_PROGRESS".GetLocalizedString()))
         {
             var nextPage = target.CurrentPage + 1;
-            var (nextPageResults, _) = await _gameDownloadManager.GetGames(
+            var (nextPageResults, _, failedDownloaders) = await _gameDownloadManager.GetGames(
                 target.LastSearchDownloaders!, target.LastSearchPayload!, nextPage);
+
+            foreach (var failedDownloader in failedDownloaders)
+            {
+                await _notificationService.AddWarningNotificationAsync("FAILED_TO_FETCH".GetLocalizedString(),
+                    "FAILED_TO_FETCH_DESCRIPTION".GetLocalizedString(failedDownloader),
+                    PackIconRemixIconKind.WifiOffLine);
+            }
 
             var fetchedResults = await InvokeMerger(target, nextPageResults.SelectMany(r => r.Sources).ToList());
 
@@ -195,7 +203,13 @@ public class GameSearchService : IViewService
             try
             {
                 var searchPayloadDto = _searchPayloadMapper.ToDto(target.SearchPayload);
-                var (games, maxTotalPages) = await _gameDownloadManager.GetGames(downloaders, searchPayloadDto, 1);
+                var (games, maxTotalPages, failedDownloaders) = await _gameDownloadManager.GetGames(downloaders, searchPayloadDto, 1);
+                foreach (var failedDownloader in failedDownloaders)
+                {
+                    await _notificationService.AddWarningNotificationAsync("FAILED_TO_FETCH".GetLocalizedString(),
+                        "FAILED_TO_FETCH_DESCRIPTION".GetLocalizedString(failedDownloader),
+                        PackIconRemixIconKind.WifiOffLine);
+                }
                 target.LastSearchPayload = searchPayloadDto;
                 target.LastSearchDownloaders = downloaders;
                 target.CurrentPage = 1;

--- a/src/TombLauncher/Services/GameSearchService.cs
+++ b/src/TombLauncher/Services/GameSearchService.cs
@@ -8,7 +8,6 @@ using AvaloniaEdit.Utils;
 using Microsoft.Extensions.Logging;
 using TombLauncher.Contracts.Downloaders;
 using TombLauncher.Contracts.Enums;
-using TombLauncher.Contracts.Localization;
 using TombLauncher.Contracts.Settings;
 using TombLauncher.Core.Extensions;
 using TombLauncher.Data.Database.Services;
@@ -48,7 +47,6 @@ public class GameSearchService : IViewService
     }
 
     public ViewServiceContext ViewContext { get; }
-    public ILocalizationManager LocalizationManager => ViewContext.LocalizationManager;
     public NavigationManager NavigationManager => ViewContext.NavigationManager;
     private readonly NotificationService _notificationService;
     private readonly ILogger<GameSearchService> _logger;

--- a/src/TombLauncher/Services/WelcomePageService.cs
+++ b/src/TombLauncher/Services/WelcomePageService.cs
@@ -7,7 +7,6 @@ using TombLauncher.Configuration;
 using TombLauncher.Contracts.Downloaders;
 using TombLauncher.Core.Dtos;
 using TombLauncher.Core.Extensions;
-using TombLauncher.Contracts.Localization;
 using TombLauncher.Contracts.Settings;
 using TombLauncher.Data.Database.Services;
 using TombLauncher.Installers.Downloaders;
@@ -56,7 +55,6 @@ public class WelcomePageService : IViewService
     private readonly GameMetadataMapper _gameMetadataMapper;
     private readonly SearchMapper _searchMapper;
     private readonly GameSearchResultService _gameSearchResultService;
-    public ILocalizationManager LocalizationManager => ViewContext.LocalizationManager;
     public NavigationManager NavigationManager => ViewContext.NavigationManager;
     private readonly GameDataService _gameDataService;
     private readonly AppCrashHostService _appCrashHostService;

--- a/src/TombLauncher/TombLauncher.csproj
+++ b/src/TombLauncher/TombLauncher.csproj
@@ -49,6 +49,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
         <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="3.1.0" />
         <PackageReference Include="NetSparkleUpdater.UI.Avalonia" Version="3.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/TombLauncher/Utils/AppUtils.cs
+++ b/src/TombLauncher/Utils/AppUtils.cs
@@ -87,13 +87,6 @@ public static class AppUtils
         return await browsingContext.OpenAsync(req => req.Content(content), cancellationToken);
     }
 
-    public static async Task<IDocument> OpenDocument(string url, CancellationToken cancellationToken)
-    {
-        var config = AngleSharpConfig.Default.WithXPath().WithDefaultLoader();
-        var browsingContext = BrowsingContext.New(config);
-        return await browsingContext.OpenAsync(url, cancellationToken);
-    }
-
     public static INode? SelectSingleNodeFromElement(this INode? node, string xpath, bool ignoreNamespaces = true)
     {
         return (node as IElement)?.SelectSingleNode(xpath, ignoreNamespaces);

--- a/src/TombLauncher/ValueConverters/ServiceCheckStatusToColorConverter.cs
+++ b/src/TombLauncher/ValueConverters/ServiceCheckStatusToColorConverter.cs
@@ -18,6 +18,7 @@ public class ServiceCheckStatusToColorConverter : IValueConverter
                 ServiceCheckStatus.Checking => Brushes.SlateGray,
                 ServiceCheckStatus.Error => Brushes.Red,
                 ServiceCheckStatus.Okay => Brushes.ForestGreen,
+                ServiceCheckStatus.Warning => Brushes.DarkOrange,
                 _ => Brushes.SlateGray
             };
         }

--- a/src/TombLauncher/ViewModels/Pages/Settings/DownloaderViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/Settings/DownloaderViewModel.cs
@@ -35,7 +35,7 @@ public partial class DownloaderViewModel : ObservableObject, IDisposable
                 return;
             }
 
-            var lastResponseTime = _responseTimeService.GetLastResponseTime(ShortClassName);
+            var lastResponseTime = _responseTimeService.GetAverageResponseTime(ShortClassName);
             if (lastResponseTime == null)
             {
                 HealthStatus.Status = ServiceCheckStatus.Unspecified;

--- a/src/TombLauncher/ViewModels/Pages/Settings/DownloaderViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/Settings/DownloaderViewModel.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using TombLauncher.Contracts.Enums;
 using TombLauncher.Installers.Resilience;
 using TombLauncher.Localization.Extensions;
+using TombLauncher.ValueConverters;
 
 namespace TombLauncher.ViewModels.Pages.Settings;
 
@@ -44,14 +46,14 @@ public partial class DownloaderViewModel : ObservableObject, IDisposable
                 HealthStatus.Status = ServiceCheckStatus.Okay;
                 HealthStatus.CheckResultMessage =
                     "DOWNLOADER_RESPONDED_IN_MS".GetLocalizedString(DisplayName,
-                        lastResponseTime.Value.TotalMilliseconds);
+                        FormatResponseTime(lastResponseTime.Value));
             }
             else
             {
                 HealthStatus.Status = ServiceCheckStatus.Warning;
                 HealthStatus.CheckResultMessage =
                     "DOWNLOADER_PERFORMANCE_DEGRADED".GetLocalizedString(DisplayName,
-                        lastResponseTime.Value.TotalMilliseconds);
+                        FormatResponseTime(lastResponseTime.Value));
             }
         });
     }
@@ -66,6 +68,15 @@ public partial class DownloaderViewModel : ObservableObject, IDisposable
     public void Dispose()
     {
         _responseTimeService.OnMeasureUpdated -= UpdateDownloaderPerfStatus;
+    }
+
+    private static string FormatResponseTime(TimeSpan t)
+    {
+        if (t.TotalMilliseconds < 500)
+            return ((int)t.TotalMilliseconds).ToString();
+
+        return new TimeSpanToHumanReadableStringConverter()
+            .Convert(t, typeof(string), null, CultureInfo.CurrentCulture) as string ?? t.ToString();
     }
     [ObservableProperty]
     public partial string BaseUrl { get; set; } = string.Empty;

--- a/src/TombLauncher/ViewModels/Pages/Settings/DownloaderViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/Settings/DownloaderViewModel.cs
@@ -1,13 +1,91 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System;
+using System.Linq;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using TombLauncher.Contracts.Enums;
+using TombLauncher.Installers.Resilience;
+using TombLauncher.Localization.Extensions;
 
 namespace TombLauncher.ViewModels.Pages.Settings;
 
-public partial class DownloaderViewModel : ObservableObject
+public partial class DownloaderViewModel : ObservableObject, IDisposable
 {
-    [ObservableProperty] private string _baseUrl = string.Empty;
-    [ObservableProperty] private string _displayName = string.Empty;
-    [ObservableProperty] private bool _isChecked;
-    [ObservableProperty] private int _priority;
-    [ObservableProperty] private string _className = string.Empty;
-    [ObservableProperty] private string _supportedFeatures = string.Empty;
+    private readonly IDownloaderResponseTimeService _responseTimeService;
+
+    private void UpdateDownloaderPerfStatus(string clientName, CircuitBreakerState state)
+    {
+        if (clientName != ShortClassName)
+            return;
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (state == CircuitBreakerState.Open)
+            {
+                HealthStatus.Status = ServiceCheckStatus.Error;
+                HealthStatus.CheckResultMessage = "CIRCUIT_BREAKER_OPEN".GetLocalizedString(DisplayName);
+                return;
+            }
+
+            if (state == CircuitBreakerState.HalfOpen)
+            {
+                HealthStatus.Status = ServiceCheckStatus.Warning;
+                HealthStatus.CheckResultMessage = "CIRCUIT_BREAKER_HALF_OPEN".GetLocalizedString(DisplayName);
+                return;
+            }
+
+            var lastResponseTime = _responseTimeService.GetLastResponseTime(ShortClassName);
+            if (lastResponseTime == null)
+            {
+                HealthStatus.Status = ServiceCheckStatus.Unspecified;
+                HealthStatus.CheckResultMessage = "NOT_ENOUGH_DATA_FOR_DOWNLOADER".GetLocalizedString(DisplayName);
+            }
+            else if (lastResponseTime.Value.TotalMilliseconds < 500)
+            {
+                HealthStatus.Status = ServiceCheckStatus.Okay;
+                HealthStatus.CheckResultMessage =
+                    "DOWNLOADER_RESPONDED_IN_MS".GetLocalizedString(DisplayName,
+                        lastResponseTime.Value.TotalMilliseconds);
+            }
+            else
+            {
+                HealthStatus.Status = ServiceCheckStatus.Warning;
+                HealthStatus.CheckResultMessage =
+                    "DOWNLOADER_PERFORMANCE_DEGRADED".GetLocalizedString(DisplayName,
+                        lastResponseTime.Value.TotalMilliseconds);
+            }
+        });
+    }
+
+    public DownloaderViewModel(IDownloaderResponseTimeService responseTimeService)
+    {
+        HealthStatus = new();
+        _responseTimeService = responseTimeService;
+        _responseTimeService.OnMeasureUpdated += UpdateDownloaderPerfStatus;
+    }
+
+    public void Dispose()
+    {
+        _responseTimeService.OnMeasureUpdated -= UpdateDownloaderPerfStatus;
+    }
+    [ObservableProperty]
+    public partial string BaseUrl { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string DisplayName { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial bool IsChecked { get; set; }
+
+    [ObservableProperty]
+    public partial int Priority { get; set; }
+
+    [ObservableProperty]
+    public partial string ClassName { get; set; } = string.Empty;
+
+    public string? ShortClassName => ClassName.Split('.').LastOrDefault();
+
+    [ObservableProperty]
+    public partial string SupportedFeatures { get; set; } = string.Empty;
+    
+    [ObservableProperty] public partial ServiceCheckViewModel HealthStatus { get; set; }
 }

--- a/src/TombLauncher/Views/DownloaderSettingsView.axaml
+++ b/src/TombLauncher/Views/DownloaderSettingsView.axaml
@@ -6,6 +6,7 @@
              xmlns:settings="clr-namespace:TombLauncher.ViewModels.Pages.Settings"
              xmlns:controls="clr-namespace:TombLauncher.Controls;assembly=TombLauncher.Controls"
              xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
+             xmlns:views="clr-namespace:TombLauncher.Views"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="TombLauncher.Views.DownloaderSettingsView"
              x:DataType="settings:DownloaderSettingsViewModel">
@@ -64,9 +65,12 @@
                             <!-- Content -->
                             <StackPanel Orientation="Vertical" Spacing="2"
                                         VerticalAlignment="Center">
-                                <TextBlock Text="{Binding DisplayName}"
-                                           FontWeight="DemiBold"
-                                           FontSize="14" />
+                                <StackPanel Orientation="Horizontal">
+                                    <views:ServiceCheckView DataContext="{Binding HealthStatus}" />
+                                    <TextBlock Text="{Binding DisplayName}"
+                                               FontWeight="DemiBold"
+                                               FontSize="14" />
+                                </StackPanel>
                                 <TextBlock Text="{Binding BaseUrl}"
                                            Classes="text-muted"
                                            FontSize="12" />


### PR DESCRIPTION
- New package: Microsoft.Extensions.Http.Resilience 10.6.0
- Per-downloader resilience pipeline: timeout 15 s, retry 3× exponential+jitter,
  circuit breaker (5 failures / 30 s sampling / 60 s break)
- ResponseTimeMeasurementHandler: DelegatingHandler that records RTT per client
- IDownloaderResponseTimeService / DownloaderResponseTimeService: singleton
  ConcurrentDictionary with CircularBuffer<TimeSpan> (10 samples) for average RTT;
  circuit breaker state tracking via OnOpened/OnHalfOpened/OnClosed callbacks
- CircularBuffer<T> in TombLauncher.Core: thread-safe, correct head-offset indexer
- AspideTR, RaidingTheGlobe, TRLE FetchDetails migrated to HttpClient.GetStringAsync
  + OpenDocumentFromContent so Polly intercepts all requests
- GameDownloadManager: per-task BrokenCircuitException handling returns partial
  results + failed downloader names; other sources unaffected when one trips
- GameSearchService: warning notification for each circuit-broken source
- DownloaderViewModel: HealthStatus badge (green/orange/red), reactive via
  OnMeasureUpdated event, Dispatcher.UIThread.Post for thread safety, IDisposable
- ServiceCheckStatus: added Warning state mapped to DarkOrange
- DownloaderSettingsView: ServiceCheckView badge per downloader row
- Localization: all 7 languages (en-US, it-IT, fr-FR, de-DE, es-ES, pl-PL, cs-CZ)

Closes #174 and #173 