### PR TITLE
fix(ai): append message text instead of tuple to fullResponse (#186)

### DIFF
--- a/src/TombLauncher/ViewModels/Pages/AiChatViewModel.cs
+++ b/src/TombLauncher/ViewModels/Pages/AiChatViewModel.cs
@@ -114,7 +114,7 @@ public partial class AiChatViewModel : PageViewModel
             else
             {
                 response.Text += messageChunk.Item2;
-                fullResponse.Append(messageChunk);
+                fullResponse.Append(messageChunk.Item2);
                 if (!responseAdded)
                 {
                     MessageHistory.Add(response);


### PR DESCRIPTION
- AiChatViewModel: fullResponse.Append(messageChunk) → fullResponse.Append(messageChunk.Item2)

Closes #186 