### PR TITLE
fix(search): notify user when no download sources are active (#188)

### DIFF
--- a/src/TombLauncher.Localization/Localization/cs-CZ.axaml
+++ b/src/TombLauncher.Localization/Localization/cs-CZ.axaml
@@ -467,6 +467,12 @@
     <system:String x:Key="CAMERA_DISTANCE_FROM_LARA">Vzdálenost mezi kamerou a Larou</system:String>
     <system:String x:Key="CAMERA_DISTANCE_HELP_TEXT">V klasických hrách Tomb Raider kamera sleduje Laru ve vzdálenosti jednoho a půl bloku, kde jeden blok je čtverec se stranou 1024 jednotek. Toto nastavení lze použít ke zvýšení nebo snížení této hodnoty. Pokud zvolíte možnost "Vlastní", zadejte hodnotu v jednotkách, nikoli v počtu bloků.</system:String>
     <system:String x:Key="CUSTOM_DISTANCE">Vlastní vzdálenost</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_BLOCK">1 blok</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_AND_HALF_BLOCKS">1,5 bloku</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_BLOCKS">2 bloky</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_AND_HALF_BLOCKS">2,5 bloku</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_THREE_BLOCKS">3 bloky</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_CUSTOM">Vlastní</system:String>
     <system:String x:Key="FOV">Zorné pole</system:String>
     <system:String x:Key="APPLY_FOV_CORRECTION">Použít korekci zorného pole</system:String>
     <system:String x:Key="FOV_HELP_TEXT">V klasických hrách Tomb Raider je horizontální zorné pole přibližně 65°. Použití záplaty widescreen bez této korekce rozšiřuje obraz, ale zachovává původní zorné pole navržené pro 4:3, což může způsobit, že kamera bude působit nepřirozeně úzce a klaustrofobicky. Zadejte šířku obrazovky v pixelech použitou v nastavení hry (např. 1920) pro výpočet korekce.</system:String>
@@ -529,6 +535,7 @@
     <system:String x:Key="ABOUT_INFO">Informace o aplikaci</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Zálohování uložených her...</system:String>
     <system:String x:Key="LICENSE">Licence</system:String>
+    <system:String x:Key="WEBSITE">Webové stránky</system:String>
     <system:String x:Key="LOGGING">Protokolování</system:String>
     <system:String x:Key="OPEN_LOGS_FOLDER">Otevřít složku protokolů</system:String>
     <system:String x:Key="KB_UPDATE_ERROR">Chyba při aktualizaci znalostní báze</system:String>
@@ -611,5 +618,7 @@
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Stahovač {0} není dostupný. Akci bude možné zopakovat přibližně za minutu.</system:String>
     <system:String x:Key="FAILED_TO_FETCH">Zdroj stahování je dočasně nedostupný</system:String>
     <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Nepodařilo se dosáhnout {0} — automatický pokus bude proveden přibližně za minutu. Pokud problém přetrvává, zvažte deaktivaci tohoto zdroje v nastavení.</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS">Žádné aktivní zdroje stahování</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS_DESCRIPTION">Nevybrali jste žádné zdroje stahování. Povolte alespoň jeden v nastavení.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/de-DE.axaml
+++ b/src/TombLauncher.Localization/Localization/de-DE.axaml
@@ -467,6 +467,12 @@
     <system:String x:Key="CAMERA_DISTANCE_FROM_LARA">Abstand zwischen Kamera und Lara</system:String>
     <system:String x:Key="CAMERA_DISTANCE_HELP_TEXT">In klassischen Tomb-Raider-Spielen folgt die Kamera Lara in einem Abstand von eineinhalb Blöcken, wobei ein Block ein Quadrat mit einer Seitenlänge von 1024 Einheiten ist. Du kannst diese Einstellung verwenden, um diesen Wert zu erhöhen oder zu verringern. Wenn du die Option "Benutzerdefiniert" wählst, gib den Wert in Einheiten an, nicht in Anzahl der Blöcke.</system:String>
     <system:String x:Key="CUSTOM_DISTANCE">Benutzerdefinierter Abstand</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_BLOCK">1 Block</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_AND_HALF_BLOCKS">1,5 Blöcke</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_BLOCKS">2 Blöcke</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_AND_HALF_BLOCKS">2,5 Blöcke</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_THREE_BLOCKS">3 Blöcke</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_CUSTOM">Benutzerdefiniert</system:String>
     <system:String x:Key="FOV">Sichtfeld</system:String>
     <system:String x:Key="APPLY_FOV_CORRECTION">Sichtfeld-Korrektur anwenden</system:String>
     <system:String x:Key="FOV_HELP_TEXT">In klassischen Tomb-Raider-Spielen beträgt das horizontale Sichtfeld etwa 65°. Das Anwenden des Widescreen-Patches ohne diese Korrektur erweitert das Bild, behält aber das ursprüngliche Sichtfeld für 4:3 bei, was die Kamera unnatürlich eng und klaustrophobisch wirken lassen kann. Gib die in der Spielkonfiguration verwendete Bildschirmbreite in Pixeln ein (z.B. 1920), um die Korrektur zu berechnen.</system:String>
@@ -529,6 +535,7 @@
     <system:String x:Key="ABOUT_INFO">Anwendungsinformationen</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Spielstände werden gesichert...</system:String>
     <system:String x:Key="LICENSE">Lizenz</system:String>
+    <system:String x:Key="WEBSITE">Website</system:String>
     <system:String x:Key="LOGGING">Protokollierung</system:String>
     <system:String x:Key="OPEN_LOGS_FOLDER">Log-Ordner öffnen</system:String>
     <system:String x:Key="KB_UPDATE_ERROR">Fehler beim Aktualisieren der Wissensdatenbank</system:String>
@@ -611,5 +618,7 @@
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Der Downloader {0} ist nicht erreichbar. Er wird in etwa einer Minute wieder verfügbar sein.</system:String>
     <system:String x:Key="FAILED_TO_FETCH">Eine Download-Quelle ist vorübergehend nicht verfügbar</system:String>
     <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">{0} ist nicht erreichbar — es wird in etwa einer Minute automatisch erneut versucht. Wenn das Problem weiterhin besteht, erwägen Sie, die Quelle in den Einstellungen zu deaktivieren.</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS">Keine aktiven Download-Quellen</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS_DESCRIPTION">Du hast keine Download-Quellen ausgewählt. Aktiviere mindestens eine in den Einstellungen.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/en-US.axaml
+++ b/src/TombLauncher.Localization/Localization/en-US.axaml
@@ -537,6 +537,7 @@
     <system:String x:Key="ABOUT_INFO">Application info</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Backing up savegames...</system:String>
     <system:String x:Key="LICENSE">License</system:String>
+    <system:String x:Key="WEBSITE">Website</system:String>
     <system:String x:Key="LOGGING">Logging</system:String>
     <system:String x:Key="OPEN_LOGS_FOLDER">Open logs folder</system:String>
     <system:String x:Key="KB_UPDATE_ERROR">Knowledge Base update error</system:String>
@@ -619,5 +620,7 @@
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Downloader {0} is unreachable. It will be available to retry in about a minute.</system:String>
     <system:String x:Key="FAILED_TO_FETCH">A download source is temporarily unavailable</system:String>
     <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Could not reach {0} — it will be retried automatically in about a minute. If it keeps failing, consider disabling it in the settings.</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS">No active download sources</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS_DESCRIPTION">You haven't selected any download sources. Enable at least one in the settings.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/es-ES.axaml
+++ b/src/TombLauncher.Localization/Localization/es-ES.axaml
@@ -467,6 +467,12 @@
     <system:String x:Key="CAMERA_DISTANCE_FROM_LARA">Distancia entre la cámara y Lara</system:String>
     <system:String x:Key="CAMERA_DISTANCE_HELP_TEXT">En los juegos clásicos de Tomb Raider, la cámara sigue a Lara a una distancia de bloque y medio, donde un bloque es un cuadrado de 1024 unidades de lado. Puedes usar esta opción para aumentar o disminuir este valor. Si eliges la opción "Personalizado", introduce el valor en unidades, no en número de bloques.</system:String>
     <system:String x:Key="CUSTOM_DISTANCE">Distancia personalizada</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_BLOCK">1 bloque</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_AND_HALF_BLOCKS">1 bloque y medio</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_BLOCKS">2 bloques</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_AND_HALF_BLOCKS">2 bloques y medio</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_THREE_BLOCKS">3 bloques</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_CUSTOM">Personalizado</system:String>
     <system:String x:Key="FOV">Campo de visión</system:String>
     <system:String x:Key="APPLY_FOV_CORRECTION">Aplicar corrección del campo de visión</system:String>
     <system:String x:Key="FOV_HELP_TEXT">En los juegos clásicos de Tomb Raider, el campo de visión horizontal es de aproximadamente 65°. Aplicar el parche de pantalla ancha sin esta corrección amplía la imagen pero mantiene el campo de visión original diseñado para 4:3, lo que puede hacer que la cámara se sienta artificialmente estrecha y claustrofóbica. Introduce la anchura de pantalla en píxeles usada en la configuración del juego (p. ej. 1920) para calcular la corrección.</system:String>
@@ -529,6 +535,7 @@
     <system:String x:Key="ABOUT_INFO">Información de la aplicación</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Haciendo copia de seguridad de las partidas guardadas...</system:String>
     <system:String x:Key="LICENSE">Licencia</system:String>
+    <system:String x:Key="WEBSITE">Sitio web</system:String>
     <system:String x:Key="LOGGING">Registro</system:String>
     <system:String x:Key="OPEN_LOGS_FOLDER">Abrir carpeta de registros</system:String>
     <system:String x:Key="KB_UPDATE_ERROR">Error de actualización de la base de conocimientos</system:String>
@@ -611,5 +618,7 @@
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">El descargador {0} no es accesible. Estará disponible para reintentar en aproximadamente un minuto.</system:String>
     <system:String x:Key="FAILED_TO_FETCH">Una fuente de descarga no está disponible temporalmente</system:String>
     <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">No se pudo contactar con {0} — se reintentará automáticamente en aproximadamente un minuto. Si el problema persiste, considera desactivarla en la configuración.</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS">No hay fuentes de descarga activas</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS_DESCRIPTION">No has seleccionado ninguna fuente de descarga. Habilita al menos una en la configuración.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/fr-FR.axaml
+++ b/src/TombLauncher.Localization/Localization/fr-FR.axaml
@@ -467,6 +467,12 @@
     <system:String x:Key="CAMERA_DISTANCE_FROM_LARA">Distance entre la caméra et Lara</system:String>
     <system:String x:Key="CAMERA_DISTANCE_HELP_TEXT">Dans les jeux Tomb Raider classiques, la caméra suit Lara à une distance d'un bloc et demi, où un bloc est un carré de 1024 unités de côté. Vous pouvez utiliser ce paramètre pour augmenter ou diminuer cette valeur. Si vous choisissez l'option "Personnalisé", entrez la valeur en unités, pas en nombre de blocs.</system:String>
     <system:String x:Key="CUSTOM_DISTANCE">Distance personnalisée</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_BLOCK">1 bloc</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_AND_HALF_BLOCKS">1 bloc et demi</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_BLOCKS">2 blocs</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_AND_HALF_BLOCKS">2 blocs et demi</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_THREE_BLOCKS">3 blocs</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_CUSTOM">Personnalisé</system:String>
     <system:String x:Key="FOV">Champ de vision</system:String>
     <system:String x:Key="APPLY_FOV_CORRECTION">Appliquer la correction du champ de vision</system:String>
     <system:String x:Key="FOV_HELP_TEXT">Dans les jeux Tomb Raider classiques, le champ de vision horizontal est d'environ 65°. L'application du patch widescreen sans cette correction élargit l'image mais conserve le champ de vision original conçu pour le 4:3, ce qui peut rendre la caméra étrangement étroite et claustrophobe. Entrez la largeur d'écran en pixels utilisée dans la configuration du jeu (ex. 1920) pour calculer la correction.</system:String>
@@ -529,6 +535,7 @@
     <system:String x:Key="ABOUT_INFO">Informations sur l'application</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Sauvegarde des parties en cours...</system:String>
     <system:String x:Key="LICENSE">Licence</system:String>
+    <system:String x:Key="WEBSITE">Site web</system:String>
     <system:String x:Key="LOGGING">Journalisation</system:String>
     <system:String x:Key="OPEN_LOGS_FOLDER">Ouvrir le dossier des journaux</system:String>
     <system:String x:Key="KB_UPDATE_ERROR">Erreur de mise à jour de la base de connaissances</system:String>
@@ -611,5 +618,7 @@
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Le téléchargeur {0} est inaccessible. Il sera disponible pour une nouvelle tentative dans environ une minute.</system:String>
     <system:String x:Key="FAILED_TO_FETCH">Une source de téléchargement est temporairement indisponible</system:String>
     <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Impossible d'atteindre {0} — une nouvelle tentative sera effectuée automatiquement dans environ une minute. Si le problème persiste, envisagez de la désactiver dans les paramètres.</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS">Aucune source de téléchargement active</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS_DESCRIPTION">Vous n'avez sélectionné aucune source de téléchargement. Activez-en au moins une dans les paramètres.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/it-IT.axaml
+++ b/src/TombLauncher.Localization/Localization/it-IT.axaml
@@ -618,5 +618,7 @@
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Il downloader {0} non è raggiungibile. Sarà possibile ritentarne l'utilizzo tra circa un minuto.</system:String>
     <system:String x:Key="FAILED_TO_FETCH">Una sorgente di download è temporaneamente non disponibile</system:String>
     <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Impossibile raggiungere {0} — verrà ritentato automaticamente tra circa un minuto. Se il problema persiste, valuta di disabilitarla nelle impostazioni.</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS">Nessuna sorgente di download attiva</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS_DESCRIPTION">Non hai selezionato nessuna sorgente di download. Abilitane almeno una nelle impostazioni.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher.Localization/Localization/pl-PL.axaml
+++ b/src/TombLauncher.Localization/Localization/pl-PL.axaml
@@ -467,6 +467,12 @@
     <system:String x:Key="CAMERA_DISTANCE_FROM_LARA">Odległość między kamerą a Larą</system:String>
     <system:String x:Key="CAMERA_DISTANCE_HELP_TEXT">W klasycznych grach Tomb Raider kamera podąża za Larą w odległości półtora bloku, gdzie jeden blok to kwadrat o boku 1024 jednostek. Możesz użyć tego ustawienia, aby zwiększyć lub zmniejszyć tę wartość. Jeśli wybierzesz opcję "Niestandardowy", podaj wartość w jednostkach, a nie w liczbie bloków.</system:String>
     <system:String x:Key="CUSTOM_DISTANCE">Niestandardowa odległość</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_BLOCK">1 blok</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_ONE_AND_HALF_BLOCKS">1,5 bloku</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_BLOCKS">2 bloki</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_TWO_AND_HALF_BLOCKS">2,5 bloku</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_THREE_BLOCKS">3 bloki</system:String>
+    <system:String x:Key="CAMERA_DISTANCE_PRESET_CUSTOM">Niestandardowy</system:String>
     <system:String x:Key="FOV">Pole widzenia</system:String>
     <system:String x:Key="APPLY_FOV_CORRECTION">Zastosuj korektę pola widzenia</system:String>
     <system:String x:Key="FOV_HELP_TEXT">W klasycznych grach Tomb Raider poziome pole widzenia wynosi około 65°. Zastosowanie łatki widescreen bez tej korekty poszerza obraz, ale zachowuje oryginalne pole widzenia zaprojektowane dla 4:3, co może sprawić, że kamera będzie wyglądać nienaturalnie wąsko i klaustrofobicznie. Wprowadź szerokość ekranu w pikselach używaną w konfiguracji gry (np. 1920), aby obliczyć korektę.</system:String>
@@ -529,6 +535,7 @@
     <system:String x:Key="ABOUT_INFO">Informacje o aplikacji</system:String>
     <system:String x:Key="BACKING_UP_SAVEGAMES">Tworzenie kopii zapasowych zapisów...</system:String>
     <system:String x:Key="LICENSE">Licencja</system:String>
+    <system:String x:Key="WEBSITE">Strona internetowa</system:String>
     <system:String x:Key="LOGGING">Rejestrowanie</system:String>
     <system:String x:Key="OPEN_LOGS_FOLDER">Otwórz folder dzienników</system:String>
     <system:String x:Key="KB_UPDATE_ERROR">Błąd aktualizacji bazy wiedzy</system:String>
@@ -611,5 +618,7 @@
     <system:String x:Key="CIRCUIT_BREAKER_OPEN">Downloader {0} jest niedostępny. Ponowienie próby będzie możliwe za około minutę.</system:String>
     <system:String x:Key="FAILED_TO_FETCH">Źródło pobierania jest tymczasowo niedostępne</system:String>
     <system:String x:Key="FAILED_TO_FETCH_DESCRIPTION">Nie można połączyć się z {0} — próba zostanie ponowiona automatycznie za około minutę. Jeśli problem się utrzymuje, rozważ wyłączenie tego źródła w ustawieniach.</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS">Brak aktywnych źródeł pobierania</system:String>
+    <system:String x:Key="NO_ACTIVE_DOWNLOADERS_DESCRIPTION">Nie wybrano żadnych źródeł pobierania. Włącz przynajmniej jedno w ustawieniach.</system:String>
     <!-- ReSharper restore InconsistentNaming -->
 </ResourceDictionary>

--- a/src/TombLauncher/Services/GameSearchService.cs
+++ b/src/TombLauncher/Services/GameSearchService.cs
@@ -199,6 +199,12 @@ public class GameSearchService : IViewService
         {
             _logger.LogInformation("Started search with parameters: {Target}", target);
             var downloaders = _settingsProvider.GetActiveDownloaders();
+            if (downloaders.Count == 0)
+            {
+                await _notificationService.AddErrorNotificationAsync("NO_ACTIVE_DOWNLOADERS".GetLocalizedString(),
+                    "NO_ACTIVE_DOWNLOADERS_DESCRIPTION".GetLocalizedString(), PackIconRemixIconKind.WifiOffFill);
+                return;
+            }
             target.FetchedResults = new ObservableCollection<MultiSourceGameSearchResultMetadataViewModel>();
             try
             {

--- a/src/TombLauncher/Services/NotificationService.cs
+++ b/src/TombLauncher/Services/NotificationService.cs
@@ -41,19 +41,9 @@ public partial class NotificationService
         await AddNotificationAsync(notificationViewModel);
     }
 
-    public void AddErrorNotification(string title, string errorMessage, PackIconRemixIconKind icon)
-    {
-        AddErrorNotificationAsync(title, errorMessage, icon).GetAwaiter().GetResult();
-    }
-
     public async Task AddErrorNotificationAsync(string errorMessage, PackIconRemixIconKind icon)
     {
         await AddErrorNotificationAsync("AN_ERROR_OCCURRED".GetLocalizedString(), errorMessage, icon);
-    }
-
-    public void AddErrorNotification(string errorMessage, PackIconRemixIconKind icon)
-    {
-        AddErrorNotificationAsync(errorMessage, icon).GetAwaiter().GetResult();
     }
 
     public async Task AddWarningNotificationAsync(string title, string message, PackIconRemixIconKind icon)


### PR DESCRIPTION
- GameSearchService: return early with NO_ACTIVE_DOWNLOADERS notification when active downloader count is zero
- NotificationService: remove synchronous AddErrorNotification wrappers
- Localization: add NO_ACTIVE_DOWNLOADERS, NO_ACTIVE_DOWNLOADERS_DESCRIPTION, WEBSITE and CAMERA_DISTANCE_PRESET_* to all 7 language files

Closes #188 