### PR TITLE
feat(search): open game details directly from a URL (#189)

### DIFF
--- a/src/TombLauncher.Contracts/Downloaders/DownloadManagerResult.cs
+++ b/src/TombLauncher.Contracts/Downloaders/DownloadManagerResult.cs
@@ -1,0 +1,11 @@
+using System.Collections.Concurrent;
+
+namespace TombLauncher.Contracts.Downloaders;
+
+public class DownloadManagerResult
+{
+    public List<IMergedGameSearchResultMetadata> Results { get; init; } = [];
+    public int? MaxTotalPages { get; set; }
+    public ConcurrentBag<string> FailedDownloaders { get; set; } = [];
+    public IGameSearchResultMetadata? Details { get; set; }
+}

--- a/src/TombLauncher.Contracts/Downloaders/IGameDetailProvider.cs
+++ b/src/TombLauncher.Contracts/Downloaders/IGameDetailProvider.cs
@@ -1,10 +1,8 @@
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace TombLauncher.Contracts.Downloaders;
 
 public interface IGameDetailProvider
 {
     string BaseUrl { get; }
     Task<IGameMetadata> FetchDetails(IGameSearchResultMetadata game, CancellationToken cancellationToken);
+    Task<IGameSearchResultMetadata?> FetchDetails(string detailId, CancellationToken cancellationToken);
 }

--- a/src/TombLauncher.Contracts/Downloaders/IGameDownloader.cs
+++ b/src/TombLauncher.Contracts/Downloaders/IGameDownloader.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using TombLauncher.Contracts.Enums;
 
 namespace TombLauncher.Contracts.Downloaders;
@@ -15,4 +16,6 @@ public interface IGameDownloader
     IGameSearchProvider Search { get; }
     IGameDetailProvider Details { get; }
     IGameInstaller Installer { get; }
+    
+    Regex? DetailsPageRegex { get; }
 }

--- a/src/TombLauncher/Installers/Downloaders/AspideTR.com/AspideTrGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/AspideTR.com/AspideTrGameDownloader.cs
@@ -32,7 +32,6 @@ public partial class AspideTrGameDownloader : GameDownloaderBase
     public override string DisplayName => "AspideTR";
     public override string BaseUrl => "https://www.aspidetr.com/";
 
-
     private readonly Dictionary<GameEngine, int?> _gameEngineMappings = new()
     {
         { GameEngine.Unknown, null },
@@ -45,7 +44,6 @@ public partial class AspideTrGameDownloader : GameDownloaderBase
     };
 
     private readonly Dictionary<string, string> _classMappings;
-
 
     private async Task ParsePage(IDocument htmlDocument, List<IGameSearchResultMetadata> result)
     {
@@ -84,7 +82,7 @@ public partial class AspideTrGameDownloader : GameDownloaderBase
             var ratings = headerNode.SelectNodesFromElement("./div[@class='stars']/a/i");
             if (ratings.IsNotNullOrEmpty())
             {
-                searchResult.Rating = ratings.Count(n => n.HasClass("fa-star")) * 2 +
+                searchResult.Rating = (ratings.Count(n => n.HasClass("fa-star")) * 2) +
                                       ratings.Count(n => n.HasClass("fa-star-half-o"));
             }
 
@@ -153,7 +151,6 @@ public partial class AspideTrGameDownloader : GameDownloaderBase
 
         return targetEncoding;
     }
-
 
     protected override async Task<ISearchResultPage> FetchPage(DownloaderSearchPayload payload, int pageNumber, CancellationToken cancellationToken)
     {
@@ -271,7 +268,6 @@ public partial class AspideTrGameDownloader : GameDownloaderBase
             }
         }
 
-
         return flags;
     }
 
@@ -338,7 +334,7 @@ public partial class AspideTrGameDownloader : GameDownloaderBase
 
         var ratings = htmlDocument.Body.SelectNodesFromElement("//div[@class='stars']/a/i");
         if (ratings.IsNotNullOrEmpty())
-            metadata.Rating = ratings.Count(n => n.HasClass("fa-star")) * 2 +
+            metadata.Rating = (ratings.Count(n => n.HasClass("fa-star")) * 2) +
                               ratings.Count(n => n.HasClass("fa-star-half-o"));
 
         var descriptionDiv = htmlDocument.Body.SelectSingleNodeFromElement("//div[contains(@class,'level-content') and contains(@class,'entry-content')]");

--- a/src/TombLauncher/Installers/Downloaders/AspideTR.com/AspideTrGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/AspideTR.com/AspideTrGameDownloader.cs
@@ -21,7 +21,7 @@ using UtfUnknown;
 
 namespace TombLauncher.Installers.Downloaders.AspideTR.com;
 
-public class AspideTrGameDownloader : GameDownloaderBase
+public partial class AspideTrGameDownloader : GameDownloaderBase
 {
     public AspideTrGameDownloader(IHttpClientFactory httpClientFactory, Dictionary<string, string> classMappings, ILogger<AspideTrGameDownloader> logger) 
         : base(httpClientFactory, logger)
@@ -199,12 +199,17 @@ public class AspideTrGameDownloader : GameDownloaderBase
         return HttpClient.DownloadAsync(metadata.DownloadLink!, stream, downloadProgress, cancellationToken);
     }
 
+    private async Task<IDocument> FetchDetailPage(string absoluteUrl, CancellationToken cancellationToken)
+    {
+        var html = await HttpClient.GetStringAsync(absoluteUrl, cancellationToken);
+        return await AppUtils.OpenDocumentFromContent(html, cancellationToken);
+    }
+
     public override async Task<IGameMetadata> FetchDetails(IGameSearchResultMetadata game,
         CancellationToken cancellationToken)
     {
         var detailsLink = new Uri(new Uri(BaseUrl), game.DetailsLink).ToString();
-        var detailsPage = await HttpClient.GetStringAsync(detailsLink, cancellationToken);
-        var htmlDocument = await AppUtils.OpenDocumentFromContent(detailsPage, cancellationToken);
+        var htmlDocument = await FetchDetailPage(detailsLink, cancellationToken);
         var dto = new GameMetadataDto()
         {
             Author = game.Author,
@@ -289,5 +294,77 @@ public class AspideTrGameDownloader : GameDownloaderBase
         if (lastListItem == null) 
             return 1;
         return int.TryParse(lastListItem.SelectSingleNodeFromElement("./a")?.TextContent, out var val) ? val : 1;
+    }
+
+    [GeneratedRegex(@"www\.aspidetr\.com/trle/levels/")]
+    private static partial Regex DetailsPageRgx();
+
+    public override Regex DetailsPageRegex => DetailsPageRgx();
+
+    public override async Task<IGameSearchResultMetadata?> FetchDetails(string detailsUrl, CancellationToken cancellationToken)
+    {
+        var htmlDocument = await FetchDetailPage(detailsUrl, cancellationToken);
+
+        var metadata = new GameSearchResultMetadataDto
+        {
+            BaseUrl = BaseUrl,
+            SourceSiteDisplayName = DisplayName,
+            DetailsLink = detailsUrl
+        };
+
+        var titleNode = htmlDocument.Body.SelectSingleNodeFromElement("//h1[@class='level-title']");
+        if (titleNode != null)
+            metadata.Title = titleNode.TextContent.Trim();
+
+        var authorNodes = htmlDocument.Body.SelectNodesFromElement("//header[@class='level-header']/em/a");
+        if (authorNodes.IsNotNullOrEmpty())
+            metadata.Author = string.Join(", ", authorNodes.Select(n => n.TextContent.Trim()));
+
+        var dateNode = htmlDocument.Body.SelectSingleNodeFromElement("//time[contains(@class,'entry-date')]");
+        if (dateNode != null && DateTime.TryParse(dateNode.GetAttributeValue("datetime"), out var releaseDate))
+            metadata.ReleaseDate = releaseDate;
+
+        var engineTypeNode = htmlDocument.Body.SelectSingleNodeFromElement("//div[contains(@class,'level-meta')]");
+        if (engineTypeNode != null)
+        {
+            var innerText = engineTypeNode.TextContent.Remove(" ");
+            var engineMatch = new Regex(@"((TombRaider\d|TEN))").Match(innerText);
+            if (engineMatch.Success)
+            {
+                Enum.TryParse<GameEngine>(engineMatch.Groups[1].Value, true, out var engine);
+                metadata.Engine = engine;
+            }
+        }
+
+        var ratings = htmlDocument.Body.SelectNodesFromElement("//div[@class='stars']/a/i");
+        if (ratings.IsNotNullOrEmpty())
+            metadata.Rating = ratings.Count(n => n.HasClass("fa-star")) * 2 +
+                              ratings.Count(n => n.HasClass("fa-star-half-o"));
+
+        var descriptionDiv = htmlDocument.Body.SelectSingleNodeFromElement("//div[contains(@class,'level-content') and contains(@class,'entry-content')]");
+        if (descriptionDiv != null)
+            metadata.Description = descriptionDiv.GetInnerHtmlOrEmpty().Trim();
+
+        var buttonsContainer = htmlDocument.Body.SelectSingleNodeFromElement("//div[contains(@class,'infos-buttons')]");
+        var buttonsLinks = buttonsContainer?.SelectNodesFromElement("./a");
+        if (buttonsLinks.IsNotNullOrEmpty())
+        {
+            foreach (var link in buttonsLinks)
+            {
+                var href = link.GetAttributeValue("href");
+                if (link.HasClass("reviews") && href != "#")
+                    metadata.ReviewsLink = href.EnsureStartsWith(BaseUrl, '/');
+                else if (link.HasClass("walkthroughs") && href != "#")
+                    metadata.WalkthroughLink = href.EnsureStartsWith(BaseUrl, '/');
+                else if (link.HasClass("download"))
+                    metadata.DownloadLink = href.EnsureStartsWith(BaseUrl, '/');
+            }
+        }
+
+        var galleryImg = htmlDocument.Body.SelectSingleNodeFromElement("//div[@class='level-gallery']//img");
+        if (galleryImg != null)
+            metadata.TitlePic = galleryImg.GetAttributeValue("src");
+
+        return metadata;
     }
 }

--- a/src/TombLauncher/Installers/Downloaders/GameDownloadManager.cs
+++ b/src/TombLauncher/Installers/Downloaders/GameDownloadManager.cs
@@ -28,12 +28,24 @@ public class GameDownloadManager
     private readonly IGameMerger _merger;
     private readonly ILogger<GameDownloadManager> _logger;
 
-    public async Task<(List<IMergedGameSearchResultMetadata> Results, int? MaxTotalPages, ConcurrentBag<string> FailedDownloaders)> GetGames(
+    public async Task<DownloadManagerResult> GetGames(
         IReadOnlyList<IGameDownloader> downloaders,
         DownloaderSearchPayload searchPayload, int page)
     {
         var failedDownloaders = new ConcurrentBag<string>();
         var outputList = new List<IMergedGameSearchResultMetadata>();
+
+        foreach (var downloader in downloaders)
+        {
+            if (downloader.DetailsPageRegex != null &&
+                downloader.DetailsPageRegex.IsMatch(searchPayload.LevelName ?? ""))
+            {
+                var details =
+                    await downloader.Details.FetchDetails(searchPayload.LevelName!, _cancellationTokenSource.Token);
+                return new DownloadManagerResult() { Details = details };
+            }
+        }
+        
         var tasks = downloaders
             .Select(async d =>
             {
@@ -53,8 +65,15 @@ public class GameDownloadManager
             .ToList();
 
         await Task.WhenAll(tasks);
-
+        
         var maxTotalPages = 0;
+        
+        var result = new DownloadManagerResult()
+        {
+            Results = outputList,
+            FailedDownloaders = failedDownloaders
+        };
+
         foreach (var completedTask in tasks.Where(t => t.Result != null))
         {
             var resultPage = completedTask.Result!;
@@ -63,7 +82,9 @@ public class GameDownloadManager
                 maxTotalPages = resultPage.TotalPages.Value;
         }
 
-        return (outputList, maxTotalPages > 0 ? maxTotalPages : null, failedDownloaders);
+        result.MaxTotalPages = maxTotalPages > 0 ? maxTotalPages : null;
+
+        return result;
     }
 
     public async Task<IGameMetadata?> FetchDetails(IGameSearchResultMetadata game)
@@ -108,8 +129,6 @@ public class GameDownloadManager
             SizeInMb = game.SizeInMb,
             SourceSiteDisplayName = game.SourceSiteDisplayName
         };
-
-        //gameClone.Sources.Add(game);
 
         Merge([gameClone], allResults);
 

--- a/src/TombLauncher/Installers/Downloaders/GameDownloaderBase.cs
+++ b/src/TombLauncher/Installers/Downloaders/GameDownloaderBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -29,6 +30,7 @@ public abstract class GameDownloaderBase : IGameDownloader, IGameSearchProvider,
     IGameSearchProvider IGameDownloader.Search => this;
     IGameDetailProvider IGameDownloader.Details => this;
     IGameInstaller IGameDownloader.Installer => this;
+    public virtual Regex? DetailsPageRegex => null;
 
     // IGameSearchProvider — stateless: all state passed as parameters
     public virtual Task<ISearchResultPage> GetGames(DownloaderSearchPayload payload, int page, CancellationToken cancellationToken)
@@ -41,6 +43,8 @@ public abstract class GameDownloaderBase : IGameDownloader, IGameSearchProvider,
 
     // IGameDetailProvider
     public abstract Task<IGameMetadata> FetchDetails(IGameSearchResultMetadata game, CancellationToken cancellationToken);
+    public virtual Task<IGameSearchResultMetadata?> FetchDetails(string detailsUrl, CancellationToken cancellationToken)
+        => Task.FromResult<IGameSearchResultMetadata?>(null);
 
     // IGameInstaller
     public abstract Task DownloadGame(IGameSearchResultMetadata metadata, Stream stream,

--- a/src/TombLauncher/Installers/Downloaders/IGameMerger.cs
+++ b/src/TombLauncher/Installers/Downloaders/IGameMerger.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using TombLauncher.Contracts.Downloaders;
-using TombLauncher.ViewModels;
 
 namespace TombLauncher.Installers.Downloaders;
 
@@ -9,5 +8,4 @@ public interface IGameMerger
     GameSearchResultMetadataDistanceCalculator Comparer { get; }
 
     int Merge(ICollection<IMergedGameSearchResultMetadata> fullList, ICollection<IGameSearchResultMetadata> addedElements);
-    //void Merge(List<GameSearchResultMetadataViewModel>)
 }

--- a/src/TombLauncher/Installers/Downloaders/RaidingTheGlobe.com/RaidingTheGlobeGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/RaidingTheGlobe.com/RaidingTheGlobeGameDownloader.cs
@@ -20,7 +20,7 @@ namespace TombLauncher.Installers.Downloaders.RaidingTheGlobe.com;
 
 public class RaidingTheGlobeGameDownloader : GameDownloaderBase
 {
-    private Dictionary<string, GameEngine> _enginesLookup = new()
+    private readonly Dictionary<string, GameEngine> _enginesLookup = new()
     {
         { "Lara Croft Tomb Raider: The Scion of Qualopec", GameEngine.TombRaider4 },
         { "Lara Croft Tomb Raider: Afterlife", GameEngine.TombRaider4 }
@@ -29,6 +29,8 @@ public class RaidingTheGlobeGameDownloader : GameDownloaderBase
     public override string DisplayName => "Raiding the Globe";
     public override string BaseUrl => "https://www.raidingtheglobe.com";
     public override DownloaderFeatures SupportedFeatures => DownloaderFeatures.LevelName;
+    public override Regex? DetailsPageRegex => null;
+
     protected override async Task<ISearchResultPage> FetchPage(DownloaderSearchPayload payload, int pageNumber, CancellationToken cancellationToken)
     {
         var uriBuilder = new UriBuilder(new Uri(BaseUrl));
@@ -158,6 +160,43 @@ public class RaidingTheGlobeGameDownloader : GameDownloaderBase
             TitlePic = titlePic,
             Author = game.Author,
             GameEngine = game.Engine
+        };
+    }
+
+    public override async Task<IGameSearchResultMetadata?> FetchDetails(string detailsUrl, CancellationToken cancellationToken)
+    {
+        var data = await FetchPage(new DownloaderSearchPayload(), 1, cancellationToken);
+        
+        var details = await FetchDetails(data.Results.FirstOrDefault()!, cancellationToken);
+
+        var fullUri = new UriBuilder(new Uri(BaseUrl));
+        fullUri.Path = detailsUrl;
+
+        var firstResult = data.Results.FirstOrDefault();
+        if (firstResult == null)
+            return null;
+
+        return new GameSearchResultMetadataDto()
+        {
+            BaseUrl = BaseUrl,
+            SourceSiteDisplayName = DisplayName,
+            Author = details.Author,
+            Engine = details.GameEngine,
+            Description = details.Description,
+            Length = details.Length,
+            TitlePic = details.TitlePicUrl,
+            Title = details.Title,
+            DetailsLink = firstResult.DetailsLink,
+            DownloadLink = firstResult.DownloadLink,
+            Rating = firstResult.Rating,
+            ReviewsLink = firstResult.ReviewsLink,
+            SizeInMb = firstResult.SizeInMb,
+            WalkthroughLink = firstResult.WalkthroughLink,
+            AuthorFullName = firstResult.AuthorFullName,
+            Difficulty = firstResult.Difficulty,
+            ReleaseDate = firstResult.ReleaseDate,
+            ReviewCount = firstResult.ReviewCount,
+            Setting = firstResult.Setting
         };
     }
 

--- a/src/TombLauncher/Installers/Downloaders/RaidingTheGlobe.com/RaidingTheGlobeGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/RaidingTheGlobe.com/RaidingTheGlobeGameDownloader.cs
@@ -18,7 +18,7 @@ using TombLauncher.Utils;
 
 namespace TombLauncher.Installers.Downloaders.RaidingTheGlobe.com;
 
-public class RaidingTheGlobeGameDownloader : GameDownloaderBase
+public partial class RaidingTheGlobeGameDownloader : GameDownloaderBase
 {
     private readonly Dictionary<string, GameEngine> _enginesLookup = new()
     {
@@ -29,7 +29,10 @@ public class RaidingTheGlobeGameDownloader : GameDownloaderBase
     public override string DisplayName => "Raiding the Globe";
     public override string BaseUrl => "https://www.raidingtheglobe.com";
     public override DownloaderFeatures SupportedFeatures => DownloaderFeatures.LevelName;
-    public override Regex? DetailsPageRegex => null;
+    public override Regex DetailsPageRegex => DetailsRegex();
+
+    [GeneratedRegex(@"raidingtheglobe.com\/downloads\/custom-games-tomb-raider-level-editor\/\d+")]
+    private static partial Regex DetailsRegex();
 
     protected override async Task<ISearchResultPage> FetchPage(DownloaderSearchPayload payload, int pageNumber, CancellationToken cancellationToken)
     {
@@ -77,6 +80,13 @@ public class RaidingTheGlobeGameDownloader : GameDownloaderBase
                 continue;
             }
 
+            var detailsLink = level.SelectSingleNodeFromElement(".//a[contains(@class, 'koowa_header__title_link')]");
+            if (detailsLink != null)
+            {
+                var detailsUrl = new Uri(new Uri(BaseUrl), detailsLink.GetAttributeValue("href")).ToString();
+                levelMetadata.DetailsLink = detailsUrl;
+            }
+
             var downloadUrl = new Uri(new Uri(BaseUrl), downloadLink.GetAttributeValue("href")).ToString();
             levelMetadata.DownloadLink = downloadUrl;
 
@@ -104,7 +114,7 @@ public class RaidingTheGlobeGameDownloader : GameDownloaderBase
         var text = dlButton.GetInnerHtml();
         if (text.IsNullOrWhiteSpace()) return null;
 
-        var match = Regex.Match(text!, @"\(.+?,\s*(?<SIZE>\d+\.?\d*)\s*(?<UNIT>MB|KB)\)");
+        var match = SizeRegex().Match(text);
         if (!match.Success) return null;
 
         return double.TryParse(match.Groups["SIZE"].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var mb)
@@ -166,15 +176,16 @@ public class RaidingTheGlobeGameDownloader : GameDownloaderBase
     public override async Task<IGameSearchResultMetadata?> FetchDetails(string detailsUrl, CancellationToken cancellationToken)
     {
         var data = await FetchPage(new DownloaderSearchPayload(), 1, cancellationToken);
-        
-        var details = await FetchDetails(data.Results.FirstOrDefault()!, cancellationToken);
 
-        var fullUri = new UriBuilder(new Uri(BaseUrl));
-        fullUri.Path = detailsUrl;
-
-        var firstResult = data.Results.FirstOrDefault();
-        if (firstResult == null)
+        var levelIdentifier = detailsUrl.Split('/').LastOrDefault();
+        if (levelIdentifier.IsNullOrWhiteSpace())
             return null;
+
+        var matchingLink = data.Results.FirstOrDefault(r => r.DetailsLink?.Split('/').LastOrDefault() == levelIdentifier);
+        if (matchingLink == null)
+            return null;
+        
+        var details = await FetchDetails(matchingLink, cancellationToken);
 
         return new GameSearchResultMetadataDto()
         {
@@ -186,17 +197,17 @@ public class RaidingTheGlobeGameDownloader : GameDownloaderBase
             Length = details.Length,
             TitlePic = details.TitlePicUrl,
             Title = details.Title,
-            DetailsLink = firstResult.DetailsLink,
-            DownloadLink = firstResult.DownloadLink,
-            Rating = firstResult.Rating,
-            ReviewsLink = firstResult.ReviewsLink,
-            SizeInMb = firstResult.SizeInMb,
-            WalkthroughLink = firstResult.WalkthroughLink,
-            AuthorFullName = firstResult.AuthorFullName,
-            Difficulty = firstResult.Difficulty,
-            ReleaseDate = firstResult.ReleaseDate,
-            ReviewCount = firstResult.ReviewCount,
-            Setting = firstResult.Setting
+            DetailsLink = matchingLink.DetailsLink,
+            DownloadLink = matchingLink.DownloadLink,
+            Rating = matchingLink.Rating,
+            ReviewsLink = matchingLink.ReviewsLink,
+            SizeInMb = matchingLink.SizeInMb,
+            WalkthroughLink = matchingLink.WalkthroughLink,
+            AuthorFullName = matchingLink.AuthorFullName,
+            Difficulty = matchingLink.Difficulty,
+            ReleaseDate = matchingLink.ReleaseDate,
+            ReviewCount = matchingLink.ReviewCount,
+            Setting = matchingLink.Setting
         };
     }
 
@@ -209,4 +220,7 @@ public class RaidingTheGlobeGameDownloader : GameDownloaderBase
     public RaidingTheGlobeGameDownloader(IHttpClientFactory httpClientFactory, ILogger<RaidingTheGlobeGameDownloader> logger) : base(httpClientFactory, logger)
     {
     }
+
+    [GeneratedRegex(@"\(.+?,\s*(?<SIZE>\d+\.?\d*)\s*(?<UNIT>MB|KB)\)")]
+    private static partial Regex SizeRegex();
 }

--- a/src/TombLauncher/Installers/Downloaders/TRCustoms.org/TrCustomsGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/TRCustoms.org/TrCustomsGameDownloader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
@@ -20,7 +21,7 @@ using TombLauncher.Installers.Downloaders.TRCustoms.org.Utils;
 
 namespace TombLauncher.Installers.Downloaders.TRCustoms.org;
 
-public class TrCustomsGameDownloader : GameDownloaderBase
+public partial class TrCustomsGameDownloader : GameDownloaderBase
 {
     public override string DisplayName => "TRCustoms.org";
     public override string BaseUrl => "https://trcustoms.org/";
@@ -59,10 +60,19 @@ public class TrCustomsGameDownloader : GameDownloaderBase
     private Dictionary<string, LevelGenreResponse> _genresMap = new();
     private readonly Dictionary<string, int> _ratingMap;
 
+    public override Regex DetailsPageRegex => DetailsRegex();
+
     public override async Task<ISearchResultPage> GetGames(DownloaderSearchPayload payload, int page, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        await InitLookups(cancellationToken);
+
+        return await FetchPage(payload, page, cancellationToken);
+    }
+
+    private async Task InitLookups(CancellationToken cancellationToken)
+    {
         if (_enginesMap.Count == 0)
         {
             var engineMapTask = FetchSupportedEngines(cancellationToken);
@@ -74,8 +84,6 @@ public class TrCustomsGameDownloader : GameDownloaderBase
             _tagsMap = tagMapTask.Result;
             _genresMap = genreMapTask.Result;
         }
-
-        return await FetchPage(payload, page, cancellationToken);
     }
 
     private async Task<TrCustomsPagedResponse<T>> GetPagedResponse<T>(string endpoint, IEnumerable<KeyValuePair<string, string?>>? trCustomsRequest = null,
@@ -189,9 +197,9 @@ public class TrCustomsGameDownloader : GameDownloaderBase
                 TitlePic = summary.Cover?.Url ?? string.Empty,
                 SizeInMb = summary.LastFile?.Size != null ? (int)Math.Ceiling(summary.LastFile.Size / (1024.0 * 1024.0)) : null,
                 ReviewCount = summary.ReviewCount,
-                ReviewsLink = $"levels/{summary.Id}/reviews".EnsureStartsWith(BaseUrl, '/'),
-                DetailsLink = $"levels/{summary.Id}".EnsureStartsWith(BaseUrl, '/'),
-                DownloadLink = summary.LastFile?.Url.EnsureStartsWith(BaseUrl, '/') ?? string.Empty
+                ReviewsLink = TrCustomsUrlUtils.GetReviewsLink(BaseUrl, summary.Id),
+                DetailsLink = TrCustomsUrlUtils.GetDetailsLink(BaseUrl, summary.Id),
+                DownloadLink = TrCustomsUrlUtils.GetDownloadLink(BaseUrl, summary.LastFile?.Url)
             };
             result.Add(metadata);
         }
@@ -321,6 +329,27 @@ public class TrCustomsGameDownloader : GameDownloaderBase
         return new SearchResultPage(result, response.LastPage);
     }
 
+    public override async Task<IGameSearchResultMetadata?> FetchDetails(string detailId, CancellationToken cancellationToken)
+    {
+        var actualId = DetailsPageRegex.Match(detailId).Groups["LEVEL_ID"].Value;
+        var request = new HttpRequestMessage
+        {
+            Method = HttpMethod.Get,
+            RequestUri = new Uri(TrCustomsUrlUtils.GetApiDetailsLink(BaseUrl, actualId))
+        };
+        using var response = await HttpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var data = JsonConvert.DeserializeObject<LevelSummaryResponse>(
+            await response.Content.ReadAsStringAsync(cancellationToken), _jsonSerializerSettings);
+        if (data == null)
+            return null;
+
+        await InitLookups(cancellationToken);
+        var searchResultMetadata = new List<IGameSearchResultMetadata>();
+        ParseResultPage([data], searchResultMetadata, cancellationToken);
+        return searchResultMetadata.First();
+    }
+
     public override async Task DownloadGame(IGameSearchResultMetadata metadata, Stream stream,
         IProgress<DownloadProgressInfo> downloadProgress,
         CancellationToken cancellationToken)
@@ -349,4 +378,7 @@ public class TrCustomsGameDownloader : GameDownloaderBase
     public override DownloaderFeatures SupportedFeatures => DownloaderFeatures.Rating | DownloaderFeatures.LevelName |
                                                    DownloaderFeatures.GameEngine | DownloaderFeatures.GameLength |
                                                    DownloaderFeatures.Setting;
+
+    [GeneratedRegex(@"trcustoms.org/levels/(?<LEVEL_ID>\d+)")]
+    private static partial Regex DetailsRegex();
 }

--- a/src/TombLauncher/Installers/Downloaders/TRCustoms.org/Utils/TrCustomsUrlUtils.cs
+++ b/src/TombLauncher/Installers/Downloaders/TRCustoms.org/Utils/TrCustomsUrlUtils.cs
@@ -1,0 +1,18 @@
+using TombLauncher.Core.Extensions;
+
+namespace TombLauncher.Installers.Downloaders.TRCustoms.org.Utils;
+
+public static class TrCustomsUrlUtils
+{
+    public static string GetReviewsLink(string baseUrl, int id) =>
+        $"levels/{id}/reviews".EnsureStartsWith(baseUrl, '/');
+
+    public static string GetDetailsLink(string baseUrl, int id) 
+        => $"levels/{id}".EnsureStartsWith(baseUrl, '/');
+    
+    public static string GetApiDetailsLink(string baseUrl, string id) 
+        => $"api/levels/{id}".EnsureStartsWith(baseUrl, '/');
+
+    public static string GetDownloadLink(string baseUrl, string? url) =>
+        url?.EnsureStartsWith(baseUrl, '/') ?? string.Empty;
+}

--- a/src/TombLauncher/Installers/Downloaders/TRLE.net/TrleGameDownloader.cs
+++ b/src/TombLauncher/Installers/Downloaders/TRLE.net/TrleGameDownloader.cs
@@ -18,7 +18,7 @@ using TombLauncher.Utils;
 
 namespace TombLauncher.Installers.Downloaders.TRLE.net;
 
-public class TrleGameDownloader : GameDownloaderBase
+public partial class TrleGameDownloader : GameDownloaderBase
 {
     public TrleGameDownloader(IHttpClientFactory httpClientFactory, ILogger<TrleGameDownloader> logger) : base(httpClientFactory, logger)
     {
@@ -191,12 +191,17 @@ public class TrleGameDownloader : GameDownloaderBase
         return HttpClient.DownloadAsync(metadata.DownloadLink!, stream, downloadProgress, cancellationToken);
     }
 
+    private async Task<IDocument> FetchDetailPage(string absoluteUrl, CancellationToken cancellationToken)
+    {
+        var html = await HttpClient.GetStringAsync(absoluteUrl, cancellationToken);
+        return await AppUtils.OpenDocumentFromContent(html, cancellationToken);
+    }
+
     public override async Task<IGameMetadata> FetchDetails(IGameSearchResultMetadata game,
         CancellationToken cancellationToken)
     {
         var detailsUrl = new Uri(new Uri(BaseUrl), game.DetailsLink).ToString();
-        var detailsPage = await HttpClient.GetStringAsync(detailsUrl, cancellationToken);
-        var htmlDocument = await AppUtils.OpenDocumentFromContent(detailsPage, cancellationToken);
+        var htmlDocument = await FetchDetailPage(detailsUrl, cancellationToken);
         var metadata = new GameMetadataDto
         {
             Author = game.Author,
@@ -267,4 +272,97 @@ public class TrleGameDownloader : GameDownloaderBase
             Idx = (pageNumber - 1) * RowsPerPage
         };
     }
+
+    public override Regex DetailsPageRegex => DetailsRegex();
+
+    public override async Task<IGameSearchResultMetadata?> FetchDetails(string detailId, CancellationToken cancellationToken)
+    {
+        var absoluteUrl = new Uri(new Uri(BaseUrl), new Uri(detailId).PathAndQuery).ToString();
+        var htmlDocument = await FetchDetailPage(absoluteUrl, cancellationToken);
+        return ScrapeSearchResultMetadata(htmlDocument, detailId);
+    }
+
+    private GameSearchResultMetadataDto ScrapeSearchResultMetadata(IDocument htmlDocument, string detailsUrl)
+    {
+        var metadata = new GameSearchResultMetadataDto
+        {
+            BaseUrl = BaseUrl,
+            SourceSiteDisplayName = DisplayName,
+            DetailsLink = detailsUrl
+        };
+
+        var headerSpan = htmlDocument.Body.SelectSingleNodeFromElement("//span[contains(@class,'subHeader')]");
+        if (headerSpan != null)
+        {
+            metadata.Title = headerSpan.ChildNodes
+                .Where(n => n.NodeType == NodeType.Text)
+                .Select(n => n.TextContent.Trim())
+                .FirstOrDefault(t => !t.IsNullOrWhiteSpace()) ?? string.Empty;
+            metadata.Author = headerSpan.SelectSingleNodeFromElement(".//a[@class='linkl']")?.TextContent.Trim();
+        }
+
+        var imageNode = htmlDocument.Body.SelectSingleNodeFromElement("//div[@align='center']/img[@class='border']");
+        if (imageNode != null)
+            metadata.TitlePic = new Uri(new Uri(BaseUrl), imageNode.GetAttributeValue("src")).ToString();
+
+        var descriptionNode = htmlDocument.Body.SelectNodesFromElement("//td[@class='medGText']").LastOrDefault();
+        metadata.Description = descriptionNode?.TextContent.Trim();
+
+        var downloadAnchor = htmlDocument.Body.SelectSingleNodeFromElement("//a[contains(@href,'trle_dl.php')]");
+        if (downloadAnchor != null)
+            metadata.DownloadLink = new Uri(new Uri(BaseUrl), downloadAnchor.GetAttributeValue("href")).ToString();
+
+        var reviewsAnchor = htmlDocument.Body.SelectSingleNodeFromElement("//a[contains(@href,'reviews.php')]");
+        if (reviewsAnchor != null)
+            metadata.ReviewsLink = new Uri(new Uri(BaseUrl), reviewsAnchor.GetAttributeValue("href")).ToString();
+
+        var walkthroughAnchor = htmlDocument.Body.SelectSingleNodeFromElement("//a[contains(@href,'Levelwalk.php')]");
+        if (walkthroughAnchor != null)
+            metadata.WalkthroughLink = new Uri(new Uri(BaseUrl), walkthroughAnchor.GetAttributeValue("href")).ToString();
+
+        var infoRows = htmlDocument.Body.SelectNodesFromElement("//tr");
+        foreach (var row in infoRows)
+        {
+            var cells = row.SelectNodesFromElement(".//td[@class='bodyText']").ToList();
+            if (cells.Count < 3) continue;
+            var label = cells[1].TextContent.Trim().TrimEnd(':');
+            var value = cells[2].TextContent.Trim();
+            if (value.IsNullOrWhiteSpace()) continue;
+            switch (label)
+            {
+                case "difficulty":
+                    metadata.Difficulty = Enum.TryParse<GameDifficulty>(value, true, out var d) ? d : GameDifficulty.Unknown;
+                    break;
+                case "duration":
+                    metadata.Length = Enum.TryParse<GameLength>(value, true, out var l) ? l : GameLength.Unknown;
+                    break;
+                case "average rating":
+                    if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var r))
+                        metadata.Rating = r;
+                    break;
+                case "file size":
+                    var sizeParts = value.Split(' ');
+                    if (sizeParts.Length >= 1 && double.TryParse(sizeParts[0], NumberStyles.Any, CultureInfo.InvariantCulture, out var sizeMb))
+                        metadata.SizeInMb = (int)Math.Ceiling(sizeMb);
+                    break;
+                case "file type":
+                    if (_inverseGameEngineMapping.TryGetValue(value, out var engine))
+                        metadata.Engine = engine;
+                    break;
+                case "release date":
+                    if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var rd))
+                        metadata.ReleaseDate = rd;
+                    break;
+                case "review count":
+                    if (int.TryParse(value, out var rc))
+                        metadata.ReviewCount = rc;
+                    break;
+            }
+        }
+
+        return metadata;
+    }
+
+    [GeneratedRegex(@"trle\.net/sc/levelfeatures\.php\?lid=(?<LEVEL_ID>\d+)")]
+    private static partial Regex DetailsRegex();
 }

--- a/src/TombLauncher/Mappers/SearchMapper.cs
+++ b/src/TombLauncher/Mappers/SearchMapper.cs
@@ -64,6 +64,32 @@ public class SearchMapper
         };
     }
 
+    public MultiSourceGameSearchResultMetadataViewModel ToViewModel(IGameSearchResultMetadata metadata, GameSearchResultService gameSearchResultService)
+    {
+        return new MultiSourceGameSearchResultMetadataViewModel(gameSearchResultService)
+        {
+            TitlePic = metadata.TitlePic ?? "",
+            Author = metadata.Author ?? "",
+            AuthorFullName = metadata.AuthorFullName ?? "",
+            BaseUrl = metadata.BaseUrl,
+            Description = metadata.Description ?? "",
+            DetailsLink = metadata.DetailsLink ?? "",
+            Difficulty = metadata.Difficulty,
+            DownloadLink = metadata.DownloadLink ?? "",
+            Engine = metadata.Engine,
+            Length = metadata.Length,
+            Rating = metadata.Rating,
+            ReleaseDate = metadata.ReleaseDate,
+            ReviewsLink = metadata.ReviewsLink ?? "",
+            Setting = metadata.Setting ?? "",
+            SizeInMb = metadata.SizeInMb,
+            Sources = [metadata],
+            Title = metadata.Title,
+            WalkthroughLink = metadata.WalkthroughLink ?? "",
+            SourceSiteDisplayName = metadata.SourceSiteDisplayName,
+        };
+    }
+
     public MultiSourceGameSearchResultMetadataViewModel ToViewModel(IMergedGameSearchResultMetadata metadata,
         GameSearchResultService gameSearchResultService)
     {

--- a/src/TombLauncher/Services/GameSearchService.cs
+++ b/src/TombLauncher/Services/GameSearchService.cs
@@ -75,21 +75,21 @@ public class GameSearchService : IViewService
         using (target.BusyScope("LOADING_IN_PROGRESS".GetLocalizedString()))
         {
             var nextPage = target.CurrentPage + 1;
-            var (nextPageResults, _, failedDownloaders) = await _gameDownloadManager.GetGames(
+            var nextPageResults = await _gameDownloadManager.GetGames(
                 target.LastSearchDownloaders!, target.LastSearchPayload!, nextPage);
 
-            foreach (var failedDownloader in failedDownloaders)
+            foreach (var failedDownloader in nextPageResults.FailedDownloaders)
             {
                 await _notificationService.AddWarningNotificationAsync("FAILED_TO_FETCH".GetLocalizedString(),
                     "FAILED_TO_FETCH_DESCRIPTION".GetLocalizedString(failedDownloader),
                     PackIconRemixIconKind.WifiOffLine);
             }
 
-            var fetchedResults = await InvokeMerger(target, nextPageResults.SelectMany(r => r.Sources).ToList());
+            var fetchedResults = await InvokeMerger(target, nextPageResults.Results.SelectMany(r => r.Sources).ToList());
 
             var gamesWithStats = await _gameDataService.GetGamesWithStats();
             var gamesByLinks = await
-                _gameLinkDataService.GetGamesByLinksDictionary(LinkType.Download, nextPageResults.SelectMany(g => g.Sources).Select(s => s.DownloadLink!).ToList(), gamesWithStats);
+                _gameLinkDataService.GetGamesByLinksDictionary(LinkType.Download, nextPageResults.Results.SelectMany(g => g.Sources).Select(s => s.DownloadLink!).ToList(), gamesWithStats);
             foreach (var game in target.FetchedResults.Where(r => r.InstalledGame == null))
             {
                 if (gamesByLinks.TryGetValue(game.DownloadLink, out var dto))
@@ -209,8 +209,16 @@ public class GameSearchService : IViewService
             try
             {
                 var searchPayloadDto = _searchPayloadMapper.ToDto(target.SearchPayload);
-                var (games, maxTotalPages, failedDownloaders) = await _gameDownloadManager.GetGames(downloaders, searchPayloadDto, 1);
-                foreach (var failedDownloader in failedDownloaders)
+                var results = await _gameDownloadManager.GetGames(downloaders, searchPayloadDto, 1);
+
+                if (results.Details != null)
+                {
+                    var vmToOpen =  _searchMapper.ToViewModel(results.Details, _gameSearchResultService);
+                    await Open(target, vmToOpen);
+                    return;
+                }
+                
+                foreach (var failedDownloader in results.FailedDownloaders)
                 {
                     await _notificationService.AddWarningNotificationAsync("FAILED_TO_FETCH".GetLocalizedString(),
                         "FAILED_TO_FETCH_DESCRIPTION".GetLocalizedString(failedDownloader),
@@ -219,9 +227,9 @@ public class GameSearchService : IViewService
                 target.LastSearchPayload = searchPayloadDto;
                 target.LastSearchDownloaders = downloaders;
                 target.CurrentPage = 1;
-                target.MaxTotalPages = maxTotalPages ?? 0;
-                var mappedGames = _searchMapper.ToViewModels(games, _gameSearchResultService).ToList();
-                var downloadLinks = games.SelectMany(g => g.Sources).Select(s => s.DownloadLink!)
+                target.MaxTotalPages = results.MaxTotalPages ?? 0;
+                var mappedGames = _searchMapper.ToViewModels(results.Results, _gameSearchResultService).ToList();
+                var downloadLinks = results.Results.SelectMany(g => g.Sources).Select(s => s.DownloadLink!)
                     .Where(s => s.IsNotNullOrWhiteSpace()).ToList();
                 var allGamesWithStats = await _gameDataService.GetGamesWithStats();
                 var installedGames = await _gameLinkDataService.GetGamesByLinksDictionary(LinkType.Download, downloadLinks, allGamesWithStats);


### PR DESCRIPTION
- Contracts: add DetailsPageRegex to IGameDownloader; add FetchDetails(string) overload to IGameDetailProvider
- Contracts: add DownloadManagerResult to replace the GetGames tuple return type
- GameDownloaderBase: add virtual DetailsPageRegex (null) and FetchDetails(string) (returns null) defaults
- GameDownloadManager: short-circuit to FetchDetails(string) when the search input matches a known detail page URL
- TrCustomsGameDownloader: implement DetailsPageRegex via [GeneratedRegex]; implement FetchDetails(string) using Newtonsoft + SnakeCaseNamingStrategy; extract TrCustomsUrlUtils for URL construction
- TrleGameDownloader: implement DetailsPageRegex; extract FetchDetailPage helper; implement FetchDetails(string) with full HTML scraping of the detail page
- RaidingTheGlobeGameDownloader: implement DetailsPageRegex; extract DetailsLink from listing HTML; implement FetchDetails(string) by matching URL segment against page-1 results
- AspideTrGameDownloader: implement DetailsPageRegex; extract FetchDetailPage helper; implement FetchDetails(string) with full HTML scraping of the detail page
- SearchMapper: add ToViewModel(IGameSearchResultMetadata) overload for single-result mapping
- GameSearchService: handle DownloadManagerResult.Details — navigate directly to the detail view instead of showing search results

Closes #189 
